### PR TITLE
Support resources with parameter-based const names

### DIFF
--- a/.gulp/regeneration.iced
+++ b/.gulp/regeneration.iced
@@ -31,7 +31,7 @@ regenExpected = (opts,done) ->
 task 'regenerate', '', (done) ->
   regenExpected {
     'outputDir': 'test/Resource/Expected',
-    'inputBaseDir': 'https://github.com/Azure/azure-rest-api-specs/blob/282efa7dd8301ba615d8741f740f1ed7f500fed1/specification',
+    'inputBaseDir': 'https://github.com/Azure/azure-rest-api-specs/blob/282efa7d/specification',
     'mappings': {
       'Microsoft.AlertsManagement': { basePath: 'alertsmanagement/resource-manager', apiVersions: [ '2018-05-05', '2018-05-05-preview', '2019-03-01', '2019-03-01-preview', '2019-05-05-preview', '2019-06-01' ]},
       'Microsoft.Attestation': { basePath: 'attestation/resource-manager', apiVersions: [ '2018-09-01-preview' ]},
@@ -74,6 +74,7 @@ task 'regenerate', '', (done) ->
       'Microsoft.ServiceBus': { basePath: 'servicebus/resource-manager', apiVersions: [ '2014-09-01', '2015-08-01', '2017-04-01', '2018-01-01-preview' ]},
       'Microsoft.ServiceFabric': { basePath: 'servicefabric/resource-manager', apiVersions: [ '2016-09-01', '2017-07-01-preview', '2018-02-01', '2019-03-01', '2019-03-01-preview', '2019-06-01-preview' ]},
       'Microsoft.ServiceFabricMesh': { basePath: 'servicefabricmesh/resource-manager', apiVersions: [ '2018-07-01-preview', '2018-09-01-preview' ]},
+      'Microsoft.Sql': { basePath: 'sql/resource-manager', apiVersions: [ '2014-04-01', '2015-05-01-preview', '2017-03-01-preview', '2017-10-01-preview', '2018-06-01-preview' ]},
       'Microsoft.SqlVirtualMachine': { basePath: 'sqlvirtualmachine/resource-manager', apiVersions: [ '2017-03-01-preview' ]},
       'Microsoft.StorageCache': { basePath: 'storagecache/resource-manager', apiVersions: [ '2019-08-01-preview', '2019-11-01' ]},
       'Microsoft.StorageSync': { basePath: 'storagesync/resource-manager', apiVersions: [ '2017-06-05-preview', '2018-04-02', '2018-07-01', '2018-10-01', '2019-02-01', '2019-03-01', '2019-06-01' ]},

--- a/test/Resource/Expected/Microsoft.ContainerRegistry/2016-06-27-preview/Microsoft.ContainerRegistry.json
+++ b/test/Resource/Expected/Microsoft.ContainerRegistry/2016-06-27-preview/Microsoft.ContainerRegistry.json
@@ -1,0 +1,119 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2016-06-27-preview/Microsoft.ContainerRegistry.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.ContainerRegistry",
+  "description": "Microsoft ContainerRegistry Resource Types",
+  "resourceDefinitions": {
+    "registries": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2016-06-27-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The location of the resource. This cannot be changed after the resource is created."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the container registry."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistryProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a container registry."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The tags of the resource."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.ContainerRegistry/registries"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerRegistry/registries"
+    }
+  },
+  "definitions": {
+    "RegistryProperties": {
+      "type": "object",
+      "properties": {
+        "adminUserEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The value that indicates whether the admin user is enabled. This value is false by default."
+        },
+        "storageAccount": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/StorageAccountProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a storage account for a container registry."
+        }
+      },
+      "required": [
+        "storageAccount"
+      ],
+      "description": "The properties of a container registry."
+    },
+    "StorageAccountProperties": {
+      "type": "object",
+      "properties": {
+        "accessKey": {
+          "type": "string",
+          "description": "The access key to the storage account."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the storage account."
+        }
+      },
+      "required": [
+        "accessKey",
+        "name"
+      ],
+      "description": "The properties of a storage account for a container registry."
+    }
+  }
+}

--- a/test/Resource/Expected/Microsoft.ContainerService/2016-03-30/Microsoft.ContainerService.json
+++ b/test/Resource/Expected/Microsoft.ContainerService/2016-03-30/Microsoft.ContainerService.json
@@ -1,0 +1,407 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2016-03-30/Microsoft.ContainerService.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.ContainerService",
+  "description": "Microsoft ContainerService Resource Types",
+  "resourceDefinitions": {
+    "containerServices": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2016-03-30"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the container service in the specified subscription and resource group."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of the container service."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.ContainerService/containerServices"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/containerServices"
+    }
+  },
+  "definitions": {
+    "ContainerServiceAgentPoolProfile": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1. "
+        },
+        "dnsPrefix": {
+          "type": "string",
+          "description": "DNS prefix to be used to create the FQDN for the agent pool."
+        },
+        "name": {
+          "type": "string",
+          "description": "Unique name of the agent pool profile in the context of the subscription and resource group."
+        },
+        "vmSize": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Standard_A0",
+                "Standard_A1",
+                "Standard_A2",
+                "Standard_A3",
+                "Standard_A4",
+                "Standard_A5",
+                "Standard_A6",
+                "Standard_A7",
+                "Standard_A8",
+                "Standard_A9",
+                "Standard_A10",
+                "Standard_A11",
+                "Standard_D1",
+                "Standard_D2",
+                "Standard_D3",
+                "Standard_D4",
+                "Standard_D11",
+                "Standard_D12",
+                "Standard_D13",
+                "Standard_D14",
+                "Standard_D1_v2",
+                "Standard_D2_v2",
+                "Standard_D3_v2",
+                "Standard_D4_v2",
+                "Standard_D5_v2",
+                "Standard_D11_v2",
+                "Standard_D12_v2",
+                "Standard_D13_v2",
+                "Standard_D14_v2",
+                "Standard_G1",
+                "Standard_G2",
+                "Standard_G3",
+                "Standard_G4",
+                "Standard_G5",
+                "Standard_DS1",
+                "Standard_DS2",
+                "Standard_DS3",
+                "Standard_DS4",
+                "Standard_DS11",
+                "Standard_DS12",
+                "Standard_DS13",
+                "Standard_DS14",
+                "Standard_GS1",
+                "Standard_GS2",
+                "Standard_GS3",
+                "Standard_GS4",
+                "Standard_GS5"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Size of agent VMs."
+        }
+      },
+      "required": [
+        "dnsPrefix",
+        "name",
+        "vmSize"
+      ],
+      "description": "Profile for the container service agent pool."
+    },
+    "ContainerServiceDiagnosticsProfile": {
+      "type": "object",
+      "properties": {
+        "vmDiagnostics": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceVMDiagnostics"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile for diagnostics on the container service VMs."
+        }
+      },
+      "required": [
+        "vmDiagnostics"
+      ]
+    },
+    "ContainerServiceLinuxProfile": {
+      "type": "object",
+      "properties": {
+        "adminUsername": {
+          "type": "string",
+          "description": "The administrator username to use for all Linux VMs"
+        },
+        "ssh": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceSshConfiguration"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "SSH configuration for Linux-based VMs running on Azure."
+        }
+      },
+      "required": [
+        "adminUsername",
+        "ssh"
+      ],
+      "description": "Profile for Linux VMs in the container service cluster."
+    },
+    "ContainerServiceMasterProfile": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "default": "1"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Number of masters (VMs) in the container service cluster. Allowed values are 1, 3, and 5. The default value is 1."
+        },
+        "dnsPrefix": {
+          "type": "string",
+          "description": "DNS prefix to be used to create the FQDN for master."
+        }
+      },
+      "required": [
+        "dnsPrefix"
+      ],
+      "description": "Profile for the container service master."
+    },
+    "ContainerServiceOrchestratorProfile": {
+      "type": "object",
+      "properties": {
+        "orchestratorType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Swarm",
+                "DCOS"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The orchestrator to use to manage container service cluster resources. Valid values are Swarm, DCOS, and Custom."
+        }
+      },
+      "required": [
+        "orchestratorType"
+      ],
+      "description": "Profile for the container service orchestrator."
+    },
+    "ContainerServiceProperties": {
+      "type": "object",
+      "properties": {
+        "agentPoolProfiles": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ContainerServiceAgentPoolProfile"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of the agent pool."
+        },
+        "diagnosticsProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceDiagnosticsProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "linuxProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceLinuxProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile for Linux VMs in the container service cluster."
+        },
+        "masterProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceMasterProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile for the container service master."
+        },
+        "orchestratorProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceOrchestratorProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile for the container service orchestrator."
+        },
+        "windowsProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceWindowsProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile for Windows VMs in the container service cluster."
+        }
+      },
+      "required": [
+        "agentPoolProfiles",
+        "linuxProfile",
+        "masterProfile"
+      ],
+      "description": "Properties of the container service."
+    },
+    "ContainerServiceSshConfiguration": {
+      "type": "object",
+      "properties": {
+        "publicKeys": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ContainerServiceSshPublicKey"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "the list of SSH public keys used to authenticate with Linux-based VMs."
+        }
+      },
+      "required": [
+        "publicKeys"
+      ],
+      "description": "SSH configuration for Linux-based VMs running on Azure."
+    },
+    "ContainerServiceSshPublicKey": {
+      "type": "object",
+      "properties": {
+        "keyData": {
+          "type": "string",
+          "description": "Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers."
+        }
+      },
+      "required": [
+        "keyData"
+      ],
+      "description": "Contains information about SSH certificate public key data."
+    },
+    "ContainerServiceVMDiagnostics": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether the VM diagnostic agent is provisioned on the VM."
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "description": "Profile for diagnostics on the container service VMs."
+    },
+    "ContainerServiceWindowsProfile": {
+      "type": "object",
+      "properties": {
+        "adminPassword": {
+          "type": "string",
+          "description": "The administrator password to use for Windows VMs"
+        },
+        "adminUsername": {
+          "type": "string",
+          "description": "The administrator username to use for Windows VMs"
+        }
+      },
+      "required": [
+        "adminPassword",
+        "adminUsername"
+      ],
+      "description": "Profile for Windows VMs in the container service cluster."
+    }
+  }
+}

--- a/test/Resource/Expected/Microsoft.DBforMariaDB/2018-06-01-preview/Microsoft.DBforMariaDB.json
+++ b/test/Resource/Expected/Microsoft.DBforMariaDB/2018-06-01-preview/Microsoft.DBforMariaDB.json
@@ -226,9 +226,7 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": [
-                "Default"
-              ]
+              "pattern": "^.*/Default$"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -727,16 +725,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "Default"
-              ]
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "Default"
           ],
           "description": "The name of the threat detection policy."
         },

--- a/test/Resource/Expected/Microsoft.DBforMariaDB/2018-06-01/Microsoft.DBforMariaDB.json
+++ b/test/Resource/Expected/Microsoft.DBforMariaDB/2018-06-01/Microsoft.DBforMariaDB.json
@@ -226,9 +226,7 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": [
-                "Default"
-              ]
+              "pattern": "^.*/Default$"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -727,16 +725,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "Default"
-              ]
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "Default"
           ],
           "description": "The name of the threat detection policy."
         },

--- a/test/Resource/Expected/Microsoft.DBforMySQL/2017-12-01-preview/Microsoft.DBforMySQL.json
+++ b/test/Resource/Expected/Microsoft.DBforMySQL/2017-12-01-preview/Microsoft.DBforMySQL.json
@@ -275,9 +275,7 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": [
-                "Default"
-              ]
+              "pattern": "^.*/Default$"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -713,14 +711,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/activeDirectory$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "activeDirectory"
           ]
         },
         "properties": {
@@ -876,16 +869,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "Default"
-              ]
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "Default"
           ],
           "description": "The name of the threat detection policy."
         },

--- a/test/Resource/Expected/Microsoft.DBforMySQL/2017-12-01/Microsoft.DBforMySQL.json
+++ b/test/Resource/Expected/Microsoft.DBforMySQL/2017-12-01/Microsoft.DBforMySQL.json
@@ -275,9 +275,7 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": [
-                "Default"
-              ]
+              "pattern": "^.*/Default$"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -713,14 +711,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/activeDirectory$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "activeDirectory"
           ]
         },
         "properties": {
@@ -876,16 +869,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "Default"
-              ]
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "Default"
           ],
           "description": "The name of the threat detection policy."
         },

--- a/test/Resource/Expected/Microsoft.DBforPostgreSQL/2017-12-01-preview/Microsoft.DBforPostgreSQL.json
+++ b/test/Resource/Expected/Microsoft.DBforPostgreSQL/2017-12-01-preview/Microsoft.DBforPostgreSQL.json
@@ -275,9 +275,7 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": [
-                "Default"
-              ]
+              "pattern": "^.*/Default$"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -717,14 +715,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/activeDirectory$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "activeDirectory"
           ]
         },
         "properties": {
@@ -880,16 +873,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "Default"
-              ]
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "Default"
           ],
           "description": "The name of the threat detection policy."
         },

--- a/test/Resource/Expected/Microsoft.DBforPostgreSQL/2017-12-01/Microsoft.DBforPostgreSQL.json
+++ b/test/Resource/Expected/Microsoft.DBforPostgreSQL/2017-12-01/Microsoft.DBforPostgreSQL.json
@@ -226,9 +226,7 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": [
-                "Default"
-              ]
+              "pattern": "^.*/Default$"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -731,16 +729,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "Default"
-              ]
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "Default"
           ],
           "description": "The name of the threat detection policy."
         },

--- a/test/Resource/Expected/Microsoft.DataBoxEdge/2019-03-01/Microsoft.DataBoxEdge.json
+++ b/test/Resource/Expected/Microsoft.DataBoxEdge/2019-03-01/Microsoft.DataBoxEdge.json
@@ -712,14 +712,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {

--- a/test/Resource/Expected/Microsoft.DataBoxEdge/2019-07-01/Microsoft.DataBoxEdge.json
+++ b/test/Resource/Expected/Microsoft.DataBoxEdge/2019-07-01/Microsoft.DataBoxEdge.json
@@ -713,14 +713,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {

--- a/test/Resource/Expected/Microsoft.DocumentDB/2015-04-08/Microsoft.DocumentDB.json
+++ b/test/Resource/Expected/Microsoft.DocumentDB/2015-04-08/Microsoft.DocumentDB.json
@@ -1362,14 +1362,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/throughput$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "throughput"
           ]
         },
         "properties": {
@@ -1447,14 +1442,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/throughput$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "throughput"
           ]
         },
         "properties": {
@@ -1532,14 +1522,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/throughput$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "throughput"
           ]
         },
         "properties": {
@@ -1683,14 +1668,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/throughput$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "throughput"
           ]
         },
         "properties": {
@@ -1768,14 +1748,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/throughput$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "throughput"
           ]
         },
         "properties": {
@@ -1814,14 +1789,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/throughput$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "throughput"
           ]
         },
         "properties": {

--- a/test/Resource/Expected/Microsoft.DocumentDB/2019-08-01/Microsoft.DocumentDB.json
+++ b/test/Resource/Expected/Microsoft.DocumentDB/2019-08-01/Microsoft.DocumentDB.json
@@ -2106,14 +2106,9 @@
           "description": "The location of the resource group to which the resource belongs."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {
@@ -2171,14 +2166,9 @@
           "description": "The location of the resource group to which the resource belongs."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {
@@ -2352,14 +2342,9 @@
           "description": "The location of the resource group to which the resource belongs."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {
@@ -2417,14 +2402,9 @@
           "description": "The location of the resource group to which the resource belongs."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {
@@ -2598,14 +2578,9 @@
           "description": "The location of the resource group to which the resource belongs."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {
@@ -2663,14 +2638,9 @@
           "description": "The location of the resource group to which the resource belongs."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {
@@ -2902,14 +2872,9 @@
           "description": "The location of the resource group to which the resource belongs."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {
@@ -3083,14 +3048,9 @@
           "description": "The location of the resource group to which the resource belongs."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {
@@ -3206,14 +3166,9 @@
           "description": "The location of the resource group to which the resource belongs."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {

--- a/test/Resource/Expected/Microsoft.EventHub/2017-04-01/Microsoft.EventHub.json
+++ b/test/Resource/Expected/Microsoft.EventHub/2017-04-01/Microsoft.EventHub.json
@@ -844,14 +844,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {

--- a/test/Resource/Expected/Microsoft.EventHub/2018-01-01-preview/Microsoft.EventHub.json
+++ b/test/Resource/Expected/Microsoft.EventHub/2018-01-01-preview/Microsoft.EventHub.json
@@ -478,14 +478,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {

--- a/test/Resource/Expected/Microsoft.HDInsight/2015-03-01-preview/Microsoft.HDInsight.json
+++ b/test/Resource/Expected/Microsoft.HDInsight/2015-03-01-preview/Microsoft.HDInsight.json
@@ -759,14 +759,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/clustermonitoring$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "clustermonitoring"
           ]
         },
         "primaryKey": {

--- a/test/Resource/Expected/Microsoft.HDInsight/2018-06-01-preview/Microsoft.HDInsight.json
+++ b/test/Resource/Expected/Microsoft.HDInsight/2018-06-01-preview/Microsoft.HDInsight.json
@@ -759,14 +759,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/clustermonitoring$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "clustermonitoring"
           ]
         },
         "primaryKey": {

--- a/test/Resource/Expected/Microsoft.ServiceBus/2017-04-01/Microsoft.ServiceBus.json
+++ b/test/Resource/Expected/Microsoft.ServiceBus/2017-04-01/Microsoft.ServiceBus.json
@@ -196,9 +196,7 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": [
-                "$default"
-              ]
+              "pattern": "^.*/$default$"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -779,16 +777,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "$default"
-              ]
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "$default"
           ],
           "description": "The configuration name. Should always be \"$default\"."
         },
@@ -828,14 +819,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {

--- a/test/Resource/Expected/Microsoft.ServiceBus/2018-01-01-preview/Microsoft.ServiceBus.json
+++ b/test/Resource/Expected/Microsoft.ServiceBus/2018-01-01-preview/Microsoft.ServiceBus.json
@@ -299,14 +299,9 @@
           ]
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {

--- a/test/Resource/Expected/Microsoft.Sql/2014-04-01/Microsoft.Sql.json
+++ b/test/Resource/Expected/Microsoft.Sql/2014-04-01/Microsoft.Sql.json
@@ -1,0 +1,2875 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2014-04-01/Microsoft.Sql.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Sql",
+  "description": "Microsoft Sql Resource Types",
+  "resourceDefinitions": {
+    "servers": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the server."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerPropertiesModel"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of a server."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/servers_connectionPolicies_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_firewallRules_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_databases_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_elasticPools_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_administrators_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_communicationLinks_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_backupLongTermRetentionVaults_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_advisors_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_disasterRecoveryConfiguration_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_auditingPolicies_childResource"
+              }
+            ]
+          }
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers"
+    },
+    "servers_administrators": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/activeDirectory$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Name of the server administrator resource."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerAdministratorProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of an server Administrator."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/administrators"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/administrators"
+    },
+    "servers_advisors": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the Server Advisor."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AdvisorPropertiesModel"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for a Database, Server or Elastic Pool Advisor."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/advisors"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/advisors"
+    },
+    "servers_auditingPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the table auditing policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerTableAuditingPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a server table auditing policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/auditingPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/auditingPolicies"
+    },
+    "servers_backupLongTermRetentionVaults": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/RegisteredVault$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the backup long term retention vault"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/BackupLongTermRetentionVaultProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a backup long term retention vault."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/backupLongTermRetentionVaults"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/backupLongTermRetentionVaults"
+    },
+    "servers_communicationLinks": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the server communication link."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerCommunicationLinkProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a server communication link."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/communicationLinks"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/communicationLinks"
+    },
+    "servers_connectionPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the connection policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerConnectionPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a server secure connection policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/connectionPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/connectionPolicies"
+    },
+    "servers_databases": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the database to be operated on (updated or created)."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of a database."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/servers_databases_securityAlertPolicies_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_databases_dataMaskingPolicies_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_databases_geoBackupPolicies_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_databases_extensions_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_databases_transparentDataEncryption_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_databases_backupLongTermRetentionPolicies_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_databases_advisors_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_databases_auditingPolicies_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_databases_connectionPolicies_childResource"
+              }
+            ]
+          }
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases"
+    },
+    "servers_databases_advisors": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the Database Advisor."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AdvisorPropertiesModel"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for a Database, Server or Elastic Pool Advisor."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/advisors"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/advisors"
+    },
+    "servers_databases_auditingPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the table auditing policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseTableAuditingPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a database table auditing policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/auditingPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/auditingPolicies"
+    },
+    "servers_databases_backupLongTermRetentionPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/Default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the backup long term retention policy"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/BackupLongTermRetentionPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a backup long term retention policy"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies"
+    },
+    "servers_databases_connectionPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the connection policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseConnectionPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a database connection policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/connectionPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/connectionPolicies"
+    },
+    "servers_databases_dataMaskingPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/Default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the database for which the data masking rule applies."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DataMaskingPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a database data masking policy."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/servers_databases_dataMaskingPolicies_rules_childResource"
+              }
+            ]
+          }
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/dataMaskingPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/dataMaskingPolicies"
+    },
+    "servers_databases_dataMaskingPolicies_rules": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the data masking rule."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DataMaskingRuleProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a database data masking rule."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/dataMaskingPolicies/rules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/dataMaskingPolicies/rules"
+    },
+    "servers_databases_extensions": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/import$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the operation to perform"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ImportExtensionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties for an import operation"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/extensions"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/extensions"
+    },
+    "servers_databases_geoBackupPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/Default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the geo backup policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/GeoBackupPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of the geo backup policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/geoBackupPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/geoBackupPolicies"
+    },
+    "servers_databases_securityAlertPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the security alert policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseSecurityAlertPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for a database Threat Detection policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/securityAlertPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/securityAlertPolicies"
+    },
+    "servers_databases_transparentDataEncryption": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/current$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the transparent data encryption configuration."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TransparentDataEncryptionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of a database transparent data encryption."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/transparentDataEncryption"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/transparentDataEncryption"
+    },
+    "servers_disasterRecoveryConfiguration": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the disaster recovery configuration to be created/updated."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/disasterRecoveryConfiguration"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/disasterRecoveryConfiguration"
+    },
+    "servers_elasticPools": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the elastic pool to be operated on (updated or created)."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ElasticPoolPropertiesModel"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of an elastic pool."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/elasticPools"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/elasticPools"
+    },
+    "servers_firewallRules": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the firewall rule."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallRuleProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of a server firewall rule."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/firewallRules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/firewallRules"
+    }
+  },
+  "definitions": {
+    "AdvisorPropertiesModel": {
+      "type": "object",
+      "properties": {
+        "autoExecuteValue": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled",
+                "Default"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets the auto-execute status (whether to let the system execute the recommendations) of this advisor. Possible values are 'Enabled' and 'Disabled'."
+        }
+      },
+      "required": [
+        "autoExecuteValue"
+      ],
+      "description": "Properties for a Database, Server or Elastic Pool Advisor."
+    },
+    "BackupLongTermRetentionPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "recoveryServicesBackupPolicyResourceId": {
+          "type": "string",
+          "description": "The azure recovery services backup protection policy resource id"
+        },
+        "state": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Disabled",
+                "Enabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The status of the backup long term retention policy."
+        }
+      },
+      "required": [
+        "recoveryServicesBackupPolicyResourceId",
+        "state"
+      ],
+      "description": "The properties of a backup long term retention policy"
+    },
+    "BackupLongTermRetentionVaultProperties": {
+      "type": "object",
+      "properties": {
+        "recoveryServicesVaultResourceId": {
+          "type": "string",
+          "description": "The azure recovery services vault resource id"
+        }
+      },
+      "required": [
+        "recoveryServicesVaultResourceId"
+      ],
+      "description": "The properties of a backup long term retention vault."
+    },
+    "DatabaseConnectionPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "proxyDnsName": {
+          "type": "string",
+          "description": "The fully qualified host name of the auditing proxy."
+        },
+        "proxyPort": {
+          "type": "string",
+          "description": "The port number of the auditing proxy."
+        },
+        "redirectionState": {
+          "type": "string",
+          "description": "The state of proxy redirection."
+        },
+        "securityEnabledAccess": {
+          "type": "string",
+          "description": "The state of security access."
+        },
+        "state": {
+          "type": "string",
+          "description": "The connection policy state."
+        },
+        "useServerDefault": {
+          "type": "string",
+          "description": "Whether server default is enabled or disabled."
+        },
+        "visibility": {
+          "type": "string",
+          "description": "The visibility of the auditing proxy."
+        }
+      },
+      "description": "Properties of a database connection policy."
+    },
+    "DatabaseProperties": {
+      "type": "object",
+      "properties": {
+        "collation": {
+          "type": "string",
+          "description": "The collation of the database. If createMode is not Default, this value is ignored."
+        },
+        "createMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Copy",
+                "Default",
+                "NonReadableSecondary",
+                "OnlineSecondary",
+                "PointInTimeRestore",
+                "Recovery",
+                "Restore",
+                "RestoreLongTermRetentionBackup",
+                "Secondary",
+                "RestoreExternalBackup",
+                "RestoreExternalBackupSecondary"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the mode of database creation.\n\nDefault: regular database creation.\n\nCopy: creates a database as a copy of an existing database. sourceDatabaseId must be specified as the resource ID of the source database.\n\nOnlineSecondary/NonReadableSecondary: creates a database as a (readable or nonreadable) secondary replica of an existing database. sourceDatabaseId must be specified as the resource ID of the existing primary database.\n\nPointInTimeRestore: Creates a database by restoring a point in time backup of an existing database. sourceDatabaseId must be specified as the resource ID of the existing database, and restorePointInTime must be specified.\n\nRecovery: Creates a database by restoring a geo-replicated backup. sourceDatabaseId must be specified as the recoverable database resource ID to restore.\n\nRestore: Creates a database by restoring a backup of a deleted database. sourceDatabaseId must be specified. If sourceDatabaseId is the database's original resource ID, then sourceDatabaseDeletionDate must be specified. Otherwise sourceDatabaseId must be the restorable dropped database resource ID and sourceDatabaseDeletionDate is ignored. restorePointInTime may also be specified to restore from an earlier point in time.\n\nRestoreLongTermRetentionBackup: Creates a database by restoring from a long term retention vault. recoveryServicesRecoveryPointResourceId must be specified as the recovery point resource ID.\n\nCopy, NonReadableSecondary, OnlineSecondary and RestoreLongTermRetentionBackup are not supported for DataWarehouse edition."
+        },
+        "edition": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Web",
+                "Business",
+                "Basic",
+                "Standard",
+                "Premium",
+                "PremiumRS",
+                "Free",
+                "Stretch",
+                "DataWarehouse",
+                "System",
+                "System2",
+                "GeneralPurpose",
+                "BusinessCritical",
+                "Hyperscale"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The edition of the database. The DatabaseEditions enumeration contains all the valid editions. If createMode is NonReadableSecondary or OnlineSecondary, this value is ignored.\r\n\r\nThe list of SKUs may vary by region and support offer. To determine the SKUs (including the SKU name, tier/edition, family, and capacity) that are available to your subscription in an Azure region, use the `Capabilities_ListByLocation` REST API or one of the following commands:\r\n\r\n```azurecli\r\naz sql db list-editions -l <location> -o table\r\n````\r\n\r\n```powershell\r\nGet-AzSqlServerServiceObjective -Location <location>\r\n````\r\n."
+        },
+        "elasticPoolName": {
+          "type": "string",
+          "description": "The name of the elastic pool the database is in. If elasticPoolName and requestedServiceObjectiveName are both updated, the value of requestedServiceObjectiveName is ignored. Not supported for DataWarehouse edition."
+        },
+        "maxSizeBytes": {
+          "type": "string",
+          "description": "The max size of the database expressed in bytes. If createMode is not Default, this value is ignored. To see possible values, query the capabilities API (/subscriptions/{subscriptionId}/providers/Microsoft.Sql/locations/{locationID}/capabilities) referred to by operationId: \"Capabilities_ListByLocation.\""
+        },
+        "readScale": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Conditional. If the database is a geo-secondary, readScale indicates whether read-only connections are allowed to this database or not. Not supported for DataWarehouse edition."
+        },
+        "recoveryServicesRecoveryPointResourceId": {
+          "type": "string",
+          "description": "Conditional. If createMode is RestoreLongTermRetentionBackup, then this value is required. Specifies the resource ID of the recovery point to restore from."
+        },
+        "requestedServiceObjectiveId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The configured service level objective ID of the database. This is the service level objective that is in the process of being applied to the database. Once successfully updated, it will match the value of currentServiceObjectiveId property. If requestedServiceObjectiveId and requestedServiceObjectiveName are both updated, the value of requestedServiceObjectiveId overrides the value of requestedServiceObjectiveName.\r\n\r\nThe list of SKUs may vary by region and support offer. To determine the service objective ids that are available to your subscription in an Azure region, use the `Capabilities_ListByLocation` REST API."
+        },
+        "requestedServiceObjectiveName": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "System",
+                "System0",
+                "System1",
+                "System2",
+                "System3",
+                "System4",
+                "System2L",
+                "System3L",
+                "System4L",
+                "Free",
+                "Basic",
+                "S0",
+                "S1",
+                "S2",
+                "S3",
+                "S4",
+                "S6",
+                "S7",
+                "S9",
+                "S12",
+                "P1",
+                "P2",
+                "P3",
+                "P4",
+                "P6",
+                "P11",
+                "P15",
+                "PRS1",
+                "PRS2",
+                "PRS4",
+                "PRS6",
+                "DW100",
+                "DW200",
+                "DW300",
+                "DW400",
+                "DW500",
+                "DW600",
+                "DW1000",
+                "DW1200",
+                "DW1000c",
+                "DW1500",
+                "DW1500c",
+                "DW2000",
+                "DW2000c",
+                "DW3000",
+                "DW2500c",
+                "DW3000c",
+                "DW6000",
+                "DW5000c",
+                "DW6000c",
+                "DW7500c",
+                "DW10000c",
+                "DW15000c",
+                "DW30000c",
+                "DS100",
+                "DS200",
+                "DS300",
+                "DS400",
+                "DS500",
+                "DS600",
+                "DS1000",
+                "DS1200",
+                "DS1500",
+                "DS2000",
+                "ElasticPool"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the configured service level objective of the database. This is the service level objective that is in the process of being applied to the database. Once successfully updated, it will match the value of serviceLevelObjective property. \r\n\r\nThe list of SKUs may vary by region and support offer. To determine the SKUs (including the SKU name, tier/edition, family, and capacity) that are available to your subscription in an Azure region, use the `Capabilities_ListByLocation` REST API or one of the following commands:\r\n\r\n```azurecli\r\naz sql db list-editions -l <location> -o table\r\n````\r\n\r\n```powershell\r\nGet-AzSqlServerServiceObjective -Location <location>\r\n````\r\n."
+        },
+        "restorePointInTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database."
+        },
+        "sampleName": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AdventureWorksLT",
+                "WideWorldImportersStd",
+                "WideWorldImportersFull"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Indicates the name of the sample schema to apply when creating this database. If createMode is not Default, this value is ignored. Not supported for DataWarehouse edition."
+        },
+        "sourceDatabaseDeletionDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specifies the time that the database was deleted."
+        },
+        "sourceDatabaseId": {
+          "type": "string",
+          "description": "The resource identifier of the source database associated with create operation of this database."
+        },
+        "zoneRedundant": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones."
+        }
+      },
+      "description": "Represents the properties of a database."
+    },
+    "DatabaseSecurityAlertPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "disabledAlerts": {
+          "type": "string",
+          "description": "Specifies the semicolon-separated list of alerts that are disabled, or empty string to disable no alerts. Possible values: Sql_Injection; Sql_Injection_Vulnerability; Access_Anomaly; Data_Exfiltration; Unsafe_Action."
+        },
+        "emailAccountAdmins": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies that the alert is sent to the account administrators."
+        },
+        "emailAddresses": {
+          "type": "string",
+          "description": "Specifies the semicolon-separated list of e-mail addresses to which the alert is sent."
+        },
+        "retentionDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of days to keep in the Threat Detection audit logs."
+        },
+        "state": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "New",
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the state of the policy. If state is Enabled, storageEndpoint and storageAccountAccessKey are required."
+        },
+        "storageAccountAccessKey": {
+          "type": "string",
+          "description": "Specifies the identifier key of the Threat Detection audit storage account. If state is Enabled, storageAccountAccessKey is required."
+        },
+        "storageEndpoint": {
+          "type": "string",
+          "description": "Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all Threat Detection audit logs. If state is Enabled, storageEndpoint is required."
+        },
+        "useServerDefault": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies whether to use the default server policy."
+        }
+      },
+      "required": [
+        "state"
+      ],
+      "description": "Properties for a database Threat Detection policy."
+    },
+    "DatabaseTableAuditingPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "auditingState": {
+          "type": "string",
+          "description": "The state of the policy."
+        },
+        "auditLogsTableName": {
+          "type": "string",
+          "description": "The audit logs table name."
+        },
+        "eventTypesToAudit": {
+          "type": "string",
+          "description": "Comma-separated list of event types to audit."
+        },
+        "fullAuditLogsTableName": {
+          "type": "string",
+          "description": "The full audit logs table name."
+        },
+        "retentionDays": {
+          "type": "string",
+          "description": "The number of days to keep in the audit logs."
+        },
+        "storageAccountKey": {
+          "type": "string",
+          "description": "The key of the auditing storage account."
+        },
+        "storageAccountName": {
+          "type": "string",
+          "description": "The table storage account name"
+        },
+        "storageAccountResourceGroupName": {
+          "type": "string",
+          "description": "The table storage account resource group name"
+        },
+        "storageAccountSecondaryKey": {
+          "type": "string",
+          "description": "The secondary key of the auditing storage account."
+        },
+        "storageAccountSubscriptionId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The table storage subscription Id."
+        },
+        "storageTableEndpoint": {
+          "type": "string",
+          "description": "The storage table endpoint."
+        },
+        "useServerDefault": {
+          "type": "string",
+          "description": "Whether server default is enabled or disabled."
+        }
+      },
+      "description": "Properties of a database table auditing policy."
+    },
+    "DataMaskingPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "dataMaskingState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Disabled",
+                "Enabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The state of the data masking policy."
+        },
+        "exemptPrincipals": {
+          "type": "string",
+          "description": "The list of the exempt principals. Specifies the semicolon-separated list of database users for which the data masking policy does not apply. The specified users receive data results without masking for all of the database queries."
+        }
+      },
+      "required": [
+        "dataMaskingState"
+      ],
+      "description": "The properties of a database data masking policy."
+    },
+    "DataMaskingRuleProperties": {
+      "type": "object",
+      "properties": {
+        "aliasName": {
+          "type": "string",
+          "description": "The alias name. This is a legacy parameter and is no longer used."
+        },
+        "columnName": {
+          "type": "string",
+          "description": "The column name on which the data masking rule is applied."
+        },
+        "maskingFunction": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Default",
+                "CCN",
+                "Email",
+                "Number",
+                "SSN",
+                "Text"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The masking function that is used for the data masking rule."
+        },
+        "numberFrom": {
+          "type": "string",
+          "description": "The numberFrom property of the masking rule. Required if maskingFunction is set to Number, otherwise this parameter will be ignored."
+        },
+        "numberTo": {
+          "type": "string",
+          "description": "The numberTo property of the data masking rule. Required if maskingFunction is set to Number, otherwise this parameter will be ignored."
+        },
+        "prefixSize": {
+          "type": "string",
+          "description": "If maskingFunction is set to Text, the number of characters to show unmasked in the beginning of the string. Otherwise, this parameter will be ignored."
+        },
+        "replacementString": {
+          "type": "string",
+          "description": "If maskingFunction is set to Text, the character to use for masking the unexposed part of the string. Otherwise, this parameter will be ignored."
+        },
+        "ruleState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Disabled",
+                "Enabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The rule state. Used to delete a rule. To delete an existing rule, specify the schemaName, tableName, columnName, maskingFunction, and specify ruleState as disabled. However, if the rule doesn't already exist, the rule will be created with ruleState set to enabled, regardless of the provided value of ruleState."
+        },
+        "schemaName": {
+          "type": "string",
+          "description": "The schema name on which the data masking rule is applied."
+        },
+        "suffixSize": {
+          "type": "string",
+          "description": "If maskingFunction is set to Text, the number of characters to show unmasked at the end of the string. Otherwise, this parameter will be ignored."
+        },
+        "tableName": {
+          "type": "string",
+          "description": "The table name on which the data masking rule is applied."
+        }
+      },
+      "required": [
+        "columnName",
+        "maskingFunction",
+        "schemaName",
+        "tableName"
+      ],
+      "description": "The properties of a database data masking rule."
+    },
+    "ElasticPoolPropertiesModel": {
+      "type": "object",
+      "properties": {
+        "databaseDtuMax": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum DTU any one database can consume."
+        },
+        "databaseDtuMin": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The minimum DTU all databases are guaranteed."
+        },
+        "dtu": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The total shared DTU for the database elastic pool."
+        },
+        "edition": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Basic",
+                "Standard",
+                "Premium",
+                "GeneralPurpose",
+                "BusinessCritical"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The edition of the elastic pool."
+        },
+        "storageMB": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets storage limit for the database elastic pool in MB."
+        },
+        "zoneRedundant": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether or not this database elastic pool is zone redundant, which means the replicas of this database will be spread across multiple availability zones."
+        }
+      },
+      "description": "Represents the properties of an elastic pool."
+    },
+    "FirewallRuleProperties": {
+      "type": "object",
+      "properties": {
+        "endIpAddress": {
+          "type": "string",
+          "description": "The end IP address of the firewall rule. Must be IPv4 format. Must be greater than or equal to startIpAddress. Use value '0.0.0.0' to represent all Azure-internal IP addresses."
+        },
+        "startIpAddress": {
+          "type": "string",
+          "description": "The start IP address of the firewall rule. Must be IPv4 format. Use value '0.0.0.0' to represent all Azure-internal IP addresses."
+        }
+      },
+      "required": [
+        "endIpAddress",
+        "startIpAddress"
+      ],
+      "description": "Represents the properties of a server firewall rule."
+    },
+    "GeoBackupPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "state": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Disabled",
+                "Enabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The state of the geo backup policy."
+        }
+      },
+      "required": [
+        "state"
+      ],
+      "description": "The properties of the geo backup policy."
+    },
+    "ImportExtensionProperties": {
+      "type": "object",
+      "properties": {
+        "administratorLogin": {
+          "type": "string",
+          "description": "The name of the SQL administrator."
+        },
+        "administratorLoginPassword": {
+          "type": "string",
+          "description": "The password of the SQL administrator."
+        },
+        "authenticationType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "SQL",
+                "ADPassword"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The authentication type."
+        },
+        "operationMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Import"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of import operation being performed. This is always Import."
+        },
+        "storageKey": {
+          "type": "string",
+          "description": "The storage key to use.  If storage key type is SharedAccessKey, it must be preceded with a \"?.\""
+        },
+        "storageKeyType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "StorageAccessKey",
+                "SharedAccessKey"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of the storage key to use."
+        },
+        "storageUri": {
+          "type": "string",
+          "description": "The storage uri to use."
+        }
+      },
+      "required": [
+        "administratorLogin",
+        "administratorLoginPassword",
+        "operationMode",
+        "storageKey",
+        "storageKeyType",
+        "storageUri"
+      ],
+      "description": "Represents the properties for an import operation"
+    },
+    "ServerAdministratorProperties": {
+      "type": "object",
+      "properties": {
+        "administratorType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "ActiveDirectory"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of administrator."
+        },
+        "login": {
+          "type": "string",
+          "description": "The server administrator login value."
+        },
+        "sid": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The server administrator Sid (Secure ID)."
+        },
+        "tenantId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The server Active Directory Administrator tenant id."
+        }
+      },
+      "required": [
+        "administratorType",
+        "login",
+        "sid",
+        "tenantId"
+      ],
+      "description": "The properties of an server Administrator."
+    },
+    "ServerCommunicationLinkProperties": {
+      "type": "object",
+      "properties": {
+        "partnerServer": {
+          "type": "string",
+          "description": "The name of the partner server."
+        }
+      },
+      "required": [
+        "partnerServer"
+      ],
+      "description": "The properties of a server communication link."
+    },
+    "ServerConnectionPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "connectionType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Default",
+                "Proxy",
+                "Redirect"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The server connection type."
+        }
+      },
+      "required": [
+        "connectionType"
+      ],
+      "description": "The properties of a server secure connection policy."
+    },
+    "ServerPropertiesModel": {
+      "type": "object",
+      "properties": {
+        "administratorLogin": {
+          "type": "string",
+          "description": "Administrator username for the server. Can only be specified when the server is being created (and is required for creation)."
+        },
+        "administratorLoginPassword": {
+          "type": "string",
+          "description": "The administrator login password (required for server creation)."
+        },
+        "version": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "2.0",
+                "12.0"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The version of the server."
+        }
+      },
+      "description": "Represents the properties of a server."
+    },
+    "servers_administrators_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "activeDirectory"
+          ],
+          "description": "Name of the server administrator resource."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerAdministratorProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of an server Administrator."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "administrators"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/administrators"
+    },
+    "servers_advisors_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the Server Advisor."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AdvisorPropertiesModel"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for a Database, Server or Elastic Pool Advisor."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "advisors"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/advisors"
+    },
+    "servers_auditingPolicies_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ],
+          "description": "The name of the table auditing policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerTableAuditingPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a server table auditing policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "auditingPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/auditingPolicies"
+    },
+    "servers_backupLongTermRetentionVaults_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "RegisteredVault"
+          ],
+          "description": "The name of the backup long term retention vault"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/BackupLongTermRetentionVaultProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a backup long term retention vault."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "backupLongTermRetentionVaults"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/backupLongTermRetentionVaults"
+    },
+    "servers_communicationLinks_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the server communication link."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerCommunicationLinkProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a server communication link."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "communicationLinks"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/communicationLinks"
+    },
+    "servers_connectionPolicies_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ],
+          "description": "The name of the connection policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerConnectionPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a server secure connection policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "connectionPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/connectionPolicies"
+    },
+    "servers_databases_advisors_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the Database Advisor."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AdvisorPropertiesModel"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for a Database, Server or Elastic Pool Advisor."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "advisors"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/advisors"
+    },
+    "servers_databases_auditingPolicies_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ],
+          "description": "The name of the table auditing policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseTableAuditingPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a database table auditing policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "auditingPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/auditingPolicies"
+    },
+    "servers_databases_backupLongTermRetentionPolicies_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "Default"
+          ],
+          "description": "The name of the backup long term retention policy"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/BackupLongTermRetentionPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a backup long term retention policy"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "backupLongTermRetentionPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies"
+    },
+    "servers_databases_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the database to be operated on (updated or created)."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of a database."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "databases"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases"
+    },
+    "servers_databases_connectionPolicies_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ],
+          "description": "The name of the connection policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseConnectionPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a database connection policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "connectionPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/connectionPolicies"
+    },
+    "servers_databases_dataMaskingPolicies_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "Default"
+          ],
+          "description": "The name of the database for which the data masking rule applies."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DataMaskingPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a database data masking policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dataMaskingPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/dataMaskingPolicies"
+    },
+    "servers_databases_dataMaskingPolicies_rules_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the data masking rule."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DataMaskingRuleProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a database data masking rule."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "rules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/dataMaskingPolicies/rules"
+    },
+    "servers_databases_extensions_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "import"
+          ],
+          "description": "The name of the operation to perform"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ImportExtensionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties for an import operation"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "extensions"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/extensions"
+    },
+    "servers_databases_geoBackupPolicies_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "Default"
+          ],
+          "description": "The name of the geo backup policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/GeoBackupPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of the geo backup policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "geoBackupPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/geoBackupPolicies"
+    },
+    "servers_databases_securityAlertPolicies_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ],
+          "description": "The name of the security alert policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseSecurityAlertPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for a database Threat Detection policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "securityAlertPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/securityAlertPolicies"
+    },
+    "servers_databases_transparentDataEncryption_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "current"
+          ],
+          "description": "The name of the transparent data encryption configuration."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TransparentDataEncryptionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of a database transparent data encryption."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "transparentDataEncryption"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/transparentDataEncryption"
+    },
+    "servers_disasterRecoveryConfiguration_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the disaster recovery configuration to be created/updated."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "disasterRecoveryConfiguration"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/disasterRecoveryConfiguration"
+    },
+    "servers_elasticPools_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the elastic pool to be operated on (updated or created)."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ElasticPoolPropertiesModel"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of an elastic pool."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "elasticPools"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/elasticPools"
+    },
+    "servers_firewallRules_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2014-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the firewall rule."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallRuleProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of a server firewall rule."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "firewallRules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/firewallRules"
+    },
+    "ServerTableAuditingPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "auditingState": {
+          "type": "string",
+          "description": "The state of the policy."
+        },
+        "auditLogsTableName": {
+          "type": "string",
+          "description": "The audit logs table name."
+        },
+        "eventTypesToAudit": {
+          "type": "string",
+          "description": "Comma-separated list of event types to audit."
+        },
+        "fullAuditLogsTableName": {
+          "type": "string",
+          "description": "The full audit logs table name."
+        },
+        "retentionDays": {
+          "type": "string",
+          "description": "The number of days to keep in the audit logs."
+        },
+        "storageAccountKey": {
+          "type": "string",
+          "description": "The key of the auditing storage account."
+        },
+        "storageAccountName": {
+          "type": "string",
+          "description": "The table storage account name"
+        },
+        "storageAccountResourceGroupName": {
+          "type": "string",
+          "description": "The table storage account resource group name"
+        },
+        "storageAccountSecondaryKey": {
+          "type": "string",
+          "description": "The secondary key of the auditing storage account."
+        },
+        "storageAccountSubscriptionId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The table storage subscription Id."
+        },
+        "storageTableEndpoint": {
+          "type": "string",
+          "description": "The storage table endpoint."
+        }
+      },
+      "description": "Properties of a server table auditing policy."
+    },
+    "TransparentDataEncryptionProperties": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The status of the database transparent data encryption."
+        }
+      },
+      "description": "Represents the properties of a database transparent data encryption."
+    }
+  }
+}

--- a/test/Resource/Expected/Microsoft.Sql/2015-05-01-preview/Microsoft.Sql.json
+++ b/test/Resource/Expected/Microsoft.Sql/2015-05-01-preview/Microsoft.Sql.json
@@ -1,0 +1,1617 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2015-05-01-preview/Microsoft.Sql.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Sql",
+  "description": "Microsoft Sql Resource Types",
+  "resourceDefinitions": {
+    "managedInstances": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ResourceIdentity"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Azure Active Directory identity configuration for a resource."
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the managed instance."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedInstanceProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a managed instance."
+        },
+        "sku": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Sku"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "An ARM Resource SKU."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances"
+    },
+    "servers": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ResourceIdentity"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Azure Active Directory identity configuration for a resource."
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the server."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a server."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/servers_encryptionProtector_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_failoverGroups_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_keys_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_syncAgents_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_virtualNetworkRules_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_firewallRules_childResource"
+              }
+            ]
+          }
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers"
+    },
+    "servers_databases_auditingSettings": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the blob auditing policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseBlobAuditingPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a database blob auditing policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/auditingSettings"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/auditingSettings"
+    },
+    "servers_databases_syncGroups": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the sync group."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SyncGroupProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a sync group."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/servers_databases_syncGroups_syncMembers_childResource"
+              }
+            ]
+          }
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/syncGroups"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/syncGroups"
+    },
+    "servers_databases_syncGroups_syncMembers": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the sync member."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SyncMemberProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a sync member."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/syncGroups/syncMembers"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/syncGroups/syncMembers"
+    },
+    "servers_encryptionProtector": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/current$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the encryption protector to be updated."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/EncryptionProtectorProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for an encryption protector execution."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/encryptionProtector"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/encryptionProtector"
+    },
+    "servers_failoverGroups": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the failover group."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FailoverGroupProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a failover group."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/failoverGroups"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/failoverGroups"
+    },
+    "servers_firewallRules": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the firewall rule."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerFirewallRuleProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a server firewall rule."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/firewallRules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/firewallRules"
+    },
+    "servers_keys": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "kind": {
+          "type": "string",
+          "description": "Kind of encryption protector. This is metadata used for the Azure portal experience."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the server key to be operated on (updated or created). The key name is required to be in the format of 'vault_key_version'. For example, if the keyId is https://YourVaultName.vault.azure.net/keys/YourKeyName/01234567890123456789012345678901, then the server key name should be formatted as: YourVaultName_YourKeyName_01234567890123456789012345678901"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerKeyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for a server key execution."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/keys"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/keys"
+    },
+    "servers_syncAgents": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the sync agent."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SyncAgentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of an Azure SQL Database sync agent."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/syncAgents"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/syncAgents"
+    },
+    "servers_virtualNetworkRules": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the virtual network rule."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/VirtualNetworkRuleProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a virtual network rule."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/virtualNetworkRules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/virtualNetworkRules"
+    }
+  },
+  "definitions": {
+    "DatabaseBlobAuditingPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "auditActionsAndGroups": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the Actions-Groups and Actions to audit.\r\n\r\nThe recommended set of action groups to use is the following combination - this will audit all the queries and stored procedures executed against the database, as well as successful and failed logins:\r\n\r\nBATCH_COMPLETED_GROUP,\r\nSUCCESSFUL_DATABASE_AUTHENTICATION_GROUP,\r\nFAILED_DATABASE_AUTHENTICATION_GROUP.\r\n\r\nThis above combination is also the set that is configured by default when enabling auditing from the Azure portal.\r\n\r\nThe supported action groups to audit are (note: choose only specific groups that cover your auditing needs. Using unnecessary groups could lead to very large quantities of audit records):\r\n\r\nAPPLICATION_ROLE_CHANGE_PASSWORD_GROUP\r\nBACKUP_RESTORE_GROUP\r\nDATABASE_LOGOUT_GROUP\r\nDATABASE_OBJECT_CHANGE_GROUP\r\nDATABASE_OBJECT_OWNERSHIP_CHANGE_GROUP\r\nDATABASE_OBJECT_PERMISSION_CHANGE_GROUP\r\nDATABASE_OPERATION_GROUP\r\nDATABASE_PERMISSION_CHANGE_GROUP\r\nDATABASE_PRINCIPAL_CHANGE_GROUP\r\nDATABASE_PRINCIPAL_IMPERSONATION_GROUP\r\nDATABASE_ROLE_MEMBER_CHANGE_GROUP\r\nFAILED_DATABASE_AUTHENTICATION_GROUP\r\nSCHEMA_OBJECT_ACCESS_GROUP\r\nSCHEMA_OBJECT_CHANGE_GROUP\r\nSCHEMA_OBJECT_OWNERSHIP_CHANGE_GROUP\r\nSCHEMA_OBJECT_PERMISSION_CHANGE_GROUP\r\nSUCCESSFUL_DATABASE_AUTHENTICATION_GROUP\r\nUSER_CHANGE_PASSWORD_GROUP\r\nBATCH_STARTED_GROUP\r\nBATCH_COMPLETED_GROUP\r\n\r\nThese are groups that cover all sql statements and stored procedures executed against the database, and should not be used in combination with other groups as this will result in duplicate audit logs.\r\n\r\nFor more information, see [Database-Level Audit Action Groups](https://docs.microsoft.com/en-us/sql/relational-databases/security/auditing/sql-server-audit-action-groups-and-actions#database-level-audit-action-groups).\r\n\r\nFor Database auditing policy, specific Actions can also be specified (note that Actions cannot be specified for Server auditing policy). The supported actions to audit are:\r\nSELECT\r\nUPDATE\r\nINSERT\r\nDELETE\r\nEXECUTE\r\nRECEIVE\r\nREFERENCES\r\n\r\nThe general form for defining an action to be audited is:\r\n{action} ON {object} BY {principal}\r\n\r\nNote that <object> in the above format can refer to an object like a table, view, or stored procedure, or an entire database or schema. For the latter cases, the forms DATABASE::{db_name} and SCHEMA::{schema_name} are used, respectively.\r\n\r\nFor example:\r\nSELECT on dbo.myTable by public\r\nSELECT on DATABASE::myDatabase by public\r\nSELECT on SCHEMA::mySchema by public\r\n\r\nFor more information, see [Database-Level Audit Actions](https://docs.microsoft.com/en-us/sql/relational-databases/security/auditing/sql-server-audit-action-groups-and-actions#database-level-audit-actions)"
+        },
+        "isAzureMonitorTargetEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies whether audit events are sent to Azure Monitor. \r\nIn order to send the events to Azure Monitor, specify 'state' as 'Enabled' and 'isAzureMonitorTargetEnabled' as true.\r\n\r\nWhen using REST API to configure auditing, Diagnostic Settings with 'SQLSecurityAuditEvents' diagnostic logs category on the database should be also created.\r\nNote that for server level audit you should use the 'master' database as {databaseName}.\r\n\r\nDiagnostic Settings URI format:\r\nPUT https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/providers/microsoft.insights/diagnosticSettings/{settingsName}?api-version=2017-05-01-preview\r\n\r\nFor more information, see [Diagnostic Settings REST API](https://go.microsoft.com/fwlink/?linkid=2033207)\r\nor [Diagnostic Settings PowerShell](https://go.microsoft.com/fwlink/?linkid=2033043)\r\n"
+        },
+        "isStorageSecondaryKeyInUse": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies whether storageAccountAccessKey value is the storage's secondary key."
+        },
+        "retentionDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of days to keep in the audit logs in the storage account."
+        },
+        "state": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the state of the policy. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required."
+        },
+        "storageAccountAccessKey": {
+          "type": "string",
+          "description": "Specifies the identifier key of the auditing storage account. If state is Enabled and storageEndpoint is specified, storageAccountAccessKey is required."
+        },
+        "storageAccountSubscriptionId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the blob storage subscription Id."
+        },
+        "storageEndpoint": {
+          "type": "string",
+          "description": "Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). If state is Enabled, storageEndpoint is required."
+        }
+      },
+      "required": [
+        "state"
+      ],
+      "description": "Properties of a database blob auditing policy."
+    },
+    "EncryptionProtectorProperties": {
+      "type": "object",
+      "properties": {
+        "serverKeyName": {
+          "type": "string",
+          "description": "The name of the server key."
+        },
+        "serverKeyType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "ServiceManaged",
+                "AzureKeyVault"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The encryption protector type like 'ServiceManaged', 'AzureKeyVault'."
+        }
+      },
+      "required": [
+        "serverKeyType"
+      ],
+      "description": "Properties for an encryption protector execution."
+    },
+    "FailoverGroupProperties": {
+      "type": "object",
+      "properties": {
+        "databases": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of databases in the failover group."
+        },
+        "partnerServers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PartnerInfo"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of partner server information for the failover group."
+        },
+        "readOnlyEndpoint": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FailoverGroupReadOnlyEndpoint"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Read-only endpoint of the failover group instance."
+        },
+        "readWriteEndpoint": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FailoverGroupReadWriteEndpoint"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Read-write endpoint of the failover group instance."
+        }
+      },
+      "required": [
+        "partnerServers",
+        "readWriteEndpoint"
+      ],
+      "description": "Properties of a failover group."
+    },
+    "FailoverGroupReadOnlyEndpoint": {
+      "type": "object",
+      "properties": {
+        "failoverPolicy": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Disabled",
+                "Enabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Failover policy of the read-only endpoint for the failover group."
+        }
+      },
+      "description": "Read-only endpoint of the failover group instance."
+    },
+    "FailoverGroupReadWriteEndpoint": {
+      "type": "object",
+      "properties": {
+        "failoverPolicy": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Manual",
+                "Automatic"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Failover policy of the read-write endpoint for the failover group. If failoverPolicy is Automatic then failoverWithDataLossGracePeriodMinutes is required."
+        },
+        "failoverWithDataLossGracePeriodMinutes": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Grace period before failover with data loss is attempted for the read-write endpoint. If failoverPolicy is Automatic then failoverWithDataLossGracePeriodMinutes is required."
+        }
+      },
+      "required": [
+        "failoverPolicy"
+      ],
+      "description": "Read-write endpoint of the failover group instance."
+    },
+    "FirewallRuleModel": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Resource name."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerFirewallRuleProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a server firewall rule."
+        }
+      },
+      "description": "A server firewall rule."
+    },
+    "ManagedInstanceProperties": {
+      "type": "object",
+      "properties": {
+        "administratorLogin": {
+          "type": "string",
+          "description": "Administrator username for the managed instance. Can only be specified when the managed instance is being created (and is required for creation)."
+        },
+        "administratorLoginPassword": {
+          "type": "string",
+          "description": "The administrator login password (required for managed instance creation)."
+        },
+        "collation": {
+          "type": "string",
+          "description": "Collation of the managed instance."
+        },
+        "dnsZonePartner": {
+          "type": "string",
+          "description": "The resource id of another managed instance whose DNS zone this managed instance will share after creation."
+        },
+        "instancePoolId": {
+          "type": "string",
+          "description": "The Id of the instance pool this managed server belongs to."
+        },
+        "licenseType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "LicenseIncluded",
+                "BasePrice"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The license type. Possible values are 'LicenseIncluded' (regular price inclusive of a new SQL license) and 'BasePrice' (discounted AHB price for bringing your own SQL licenses)."
+        },
+        "managedInstanceCreateMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Default",
+                "PointInTimeRestore"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the mode of database creation.\r\n\r\nDefault: Regular instance creation.\r\n\r\nRestore: Creates an instance by restoring a set of backups to specific point in time. RestorePointInTime and SourceManagedInstanceId must be specified."
+        },
+        "proxyOverride": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Proxy",
+                "Redirect",
+                "Default"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Connection type used for connecting to the instance."
+        },
+        "publicDataEndpointEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether or not the public data endpoint is enabled."
+        },
+        "restorePointInTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database."
+        },
+        "sourceManagedInstanceId": {
+          "type": "string",
+          "description": "The resource identifier of the source managed instance associated with create operation of this instance."
+        },
+        "storageSizeInGB": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Storage size in GB. Minimum value: 32. Maximum value: 8192. Increments of 32 GB allowed only."
+        },
+        "subnetId": {
+          "type": "string",
+          "description": "Subnet resource ID for the managed instance."
+        },
+        "timezoneId": {
+          "type": "string",
+          "description": "Id of the timezone. Allowed values are timezones supported by Windows.\r\nWindows keeps details on supported timezones, including the id, in registry under\r\nKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Time Zones.\r\nYou can get those registry values via SQL Server by querying SELECT name AS timezone_id FROM sys.time_zone_info.\r\nList of Ids can also be obtained by executing [System.TimeZoneInfo]::GetSystemTimeZones() in PowerShell.\r\nAn example of valid timezone id is \"Pacific Standard Time\" or \"W. Europe Standard Time\"."
+        },
+        "vCores": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The number of vCores. Allowed values: 8, 16, 24, 32, 40, 64, 80."
+        }
+      },
+      "description": "The properties of a managed instance."
+    },
+    "PartnerInfo": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource identifier of the partner server."
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "description": "Partner server information for the failover group."
+    },
+    "ResourceIdentity": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "SystemAssigned"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The identity type. Set this to 'SystemAssigned' in order to automatically create and assign an Azure Active Directory principal for the resource."
+        }
+      },
+      "description": "Azure Active Directory identity configuration for a resource."
+    },
+    "ServerFirewallRuleProperties": {
+      "type": "object",
+      "properties": {
+        "endIpAddress": {
+          "type": "string",
+          "description": "The end IP address of the firewall rule. Must be IPv4 format. Must be greater than or equal to startIpAddress. Use value '0.0.0.0' for all Azure-internal IP addresses."
+        },
+        "startIpAddress": {
+          "type": "string",
+          "description": "The start IP address of the firewall rule. Must be IPv4 format. Use value '0.0.0.0' for all Azure-internal IP addresses."
+        }
+      },
+      "description": "The properties of a server firewall rule."
+    },
+    "ServerKeyProperties": {
+      "type": "object",
+      "properties": {
+        "creationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The server key creation date."
+        },
+        "serverKeyType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "ServiceManaged",
+                "AzureKeyVault"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The server key type like 'ServiceManaged', 'AzureKeyVault'."
+        },
+        "thumbprint": {
+          "type": "string",
+          "description": "Thumbprint of the server key."
+        },
+        "uri": {
+          "type": "string",
+          "description": "The URI of the server key."
+        }
+      },
+      "required": [
+        "serverKeyType"
+      ],
+      "description": "Properties for a server key execution."
+    },
+    "ServerProperties": {
+      "type": "object",
+      "properties": {
+        "administratorLogin": {
+          "type": "string",
+          "description": "Administrator username for the server. Once created it cannot be changed."
+        },
+        "administratorLoginPassword": {
+          "type": "string",
+          "description": "The administrator login password (required for server creation)."
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the server."
+        }
+      },
+      "description": "The properties of a server."
+    },
+    "servers_databases_syncGroups_syncMembers_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the sync member."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SyncMemberProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a sync member."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "syncMembers"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/syncGroups/syncMembers"
+    },
+    "servers_encryptionProtector_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "current"
+          ],
+          "description": "The name of the encryption protector to be updated."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/EncryptionProtectorProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for an encryption protector execution."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "encryptionProtector"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/encryptionProtector"
+    },
+    "servers_failoverGroups_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the failover group."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FailoverGroupProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a failover group."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "failoverGroups"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/failoverGroups"
+    },
+    "servers_firewallRules_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the firewall rule."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerFirewallRuleProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a server firewall rule."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "firewallRules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/firewallRules"
+    },
+    "servers_keys_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "kind": {
+          "type": "string",
+          "description": "Kind of encryption protector. This is metadata used for the Azure portal experience."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the server key to be operated on (updated or created). The key name is required to be in the format of 'vault_key_version'. For example, if the keyId is https://YourVaultName.vault.azure.net/keys/YourKeyName/01234567890123456789012345678901, then the server key name should be formatted as: YourVaultName_YourKeyName_01234567890123456789012345678901"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerKeyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for a server key execution."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "keys"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/keys"
+    },
+    "servers_syncAgents_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the sync agent."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SyncAgentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of an Azure SQL Database sync agent."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "syncAgents"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/syncAgents"
+    },
+    "servers_virtualNetworkRules_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-05-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the virtual network rule."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/VirtualNetworkRuleProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a virtual network rule."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "virtualNetworkRules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/virtualNetworkRules"
+    },
+    "Sku": {
+      "type": "object",
+      "properties": {
+        "capacity": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Capacity of the particular SKU."
+        },
+        "family": {
+          "type": "string",
+          "description": "If the service has different generations of hardware, for the same SKU, then that can be captured here."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the SKU, typically, a letter + Number code, e.g. P3."
+        },
+        "size": {
+          "type": "string",
+          "description": "Size of the particular SKU"
+        },
+        "tier": {
+          "type": "string",
+          "description": "The tier or edition of the particular SKU, e.g. Basic, Premium."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "description": "An ARM Resource SKU."
+    },
+    "SyncAgentProperties": {
+      "type": "object",
+      "properties": {
+        "syncDatabaseId": {
+          "type": "string",
+          "description": "ARM resource id of the sync database in the sync agent."
+        }
+      },
+      "description": "Properties of an Azure SQL Database sync agent."
+    },
+    "SyncGroupProperties": {
+      "type": "object",
+      "properties": {
+        "conflictResolutionPolicy": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "HubWin",
+                "MemberWin"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Conflict resolution policy of the sync group."
+        },
+        "hubDatabasePassword": {
+          "type": "string",
+          "description": "Password for the sync group hub database credential."
+        },
+        "hubDatabaseUserName": {
+          "type": "string",
+          "description": "User name for the sync group hub database credential."
+        },
+        "interval": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sync interval of the sync group."
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SyncGroupSchema"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of sync group schema."
+        },
+        "syncDatabaseId": {
+          "type": "string",
+          "description": "ARM resource id of the sync database in the sync group."
+        }
+      },
+      "description": "Properties of a sync group."
+    },
+    "SyncGroupSchema": {
+      "type": "object",
+      "properties": {
+        "masterSyncMemberName": {
+          "type": "string",
+          "description": "Name of master sync member where the schema is from."
+        },
+        "tables": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SyncGroupSchemaTable"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of tables in sync group schema."
+        }
+      },
+      "description": "Properties of sync group schema."
+    },
+    "SyncGroupSchemaTable": {
+      "type": "object",
+      "properties": {
+        "columns": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SyncGroupSchemaTableColumn"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of columns in sync group schema."
+        },
+        "quotedName": {
+          "type": "string",
+          "description": "Quoted name of sync group schema table."
+        }
+      },
+      "description": "Properties of table in sync group schema."
+    },
+    "SyncGroupSchemaTableColumn": {
+      "type": "object",
+      "properties": {
+        "dataSize": {
+          "type": "string",
+          "description": "Data size of the column."
+        },
+        "dataType": {
+          "type": "string",
+          "description": "Data type of the column."
+        },
+        "quotedName": {
+          "type": "string",
+          "description": "Quoted name of sync group table column."
+        }
+      },
+      "description": "Properties of column in sync group table."
+    },
+    "SyncMemberProperties": {
+      "type": "object",
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Database name of the member database in the sync member."
+        },
+        "databaseType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AzureSqlDatabase",
+                "SqlServerDatabase"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Database type of the sync member."
+        },
+        "password": {
+          "type": "string",
+          "description": "Password of the member database in the sync member."
+        },
+        "serverName": {
+          "type": "string",
+          "description": "Server name of the member database in the sync member"
+        },
+        "sqlServerDatabaseId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "SQL Server database id of the sync member."
+        },
+        "syncAgentId": {
+          "type": "string",
+          "description": "ARM resource id of the sync agent in the sync member."
+        },
+        "syncDirection": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Bidirectional",
+                "OneWayMemberToHub",
+                "OneWayHubToMember"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sync direction of the sync member."
+        },
+        "userName": {
+          "type": "string",
+          "description": "User name of the member database in the sync member."
+        }
+      },
+      "description": "Properties of a sync member."
+    },
+    "VirtualNetworkRuleProperties": {
+      "type": "object",
+      "properties": {
+        "ignoreMissingVnetServiceEndpoint": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Create firewall rule before the virtual network has vnet service endpoint enabled."
+        },
+        "virtualNetworkSubnetId": {
+          "type": "string",
+          "description": "The ARM resource id of the virtual network subnet."
+        }
+      },
+      "required": [
+        "virtualNetworkSubnetId"
+      ],
+      "description": "Properties of a virtual network rule."
+    }
+  }
+}

--- a/test/Resource/Expected/Microsoft.Sql/2017-03-01-preview/Microsoft.Sql.json
+++ b/test/Resource/Expected/Microsoft.Sql/2017-03-01-preview/Microsoft.Sql.json
@@ -1,0 +1,2921 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2017-03-01-preview/Microsoft.Sql.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Sql",
+  "description": "Microsoft Sql Resource Types",
+  "resourceDefinitions": {
+    "managedInstances_administrators": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The requested administrator name."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedInstanceAdministratorProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a managed instance administrator."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances/administrators"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/administrators"
+    },
+    "managedInstances_databases": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the database."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedDatabaseProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The managed database's properties."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/managedInstances_databases_backupShortTermRetentionPolicies_childResource"
+              },
+              {
+                "$ref": "#/definitions/managedInstances_databases_securityAlertPolicies_childResource"
+              }
+            ]
+          }
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances/databases"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/databases"
+    },
+    "managedInstances_databases_backupShortTermRetentionPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The policy name. Should always be \"default\"."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedBackupShortTermRetentionPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a short term retention policy"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances/databases/backupShortTermRetentionPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/databases/backupShortTermRetentionPolicies"
+    },
+    "managedInstances_databases_securityAlertPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/Default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the security alert policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SecurityAlertPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a security alert policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances/databases/securityAlertPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/databases/securityAlertPolicies"
+    },
+    "managedInstances_restorableDroppedDatabases_backupShortTermRetentionPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The policy name. Should always be \"default\"."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedBackupShortTermRetentionPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a short term retention policy"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances/restorableDroppedDatabases/backupShortTermRetentionPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/restorableDroppedDatabases/backupShortTermRetentionPolicies"
+    },
+    "managedInstances_securityAlertPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/Default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the security alert policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SecurityAlertPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a security alert policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances/securityAlertPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/securityAlertPolicies"
+    },
+    "servers_auditingSettings": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the blob auditing policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerBlobAuditingPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a server blob auditing policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/auditingSettings"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/auditingSettings"
+    },
+    "servers_databases": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the database."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabasePropertiesModel"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The database's properties."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/servers_databases_extendedAuditingSettings_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_databases_auditingSettings_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_databases_vulnerabilityAssessments_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_databases_backupLongTermRetentionPolicies_childResource"
+              }
+            ]
+          }
+        },
+        "sku": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Sku"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "An ARM Resource SKU."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases"
+    },
+    "servers_databases_auditingSettings": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the blob auditing policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseBlobAuditingPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a database blob auditing policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/auditingSettings"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/auditingSettings"
+    },
+    "servers_databases_backupLongTermRetentionPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The policy name. Should always be Default."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/LongTermRetentionPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a long term retention policy"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies"
+    },
+    "servers_databases_extendedAuditingSettings": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the blob auditing policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ExtendedDatabaseBlobAuditingPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of an extended database blob auditing policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/extendedAuditingSettings"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/extendedAuditingSettings"
+    },
+    "servers_databases_schemas_tables_columns_sensitivityLabels": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/recommended$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The source of the sensitivity label."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SensitivityLabelProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a sensitivity label."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/schemas/tables/columns/sensitivityLabels"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/schemas/tables/columns/sensitivityLabels"
+    },
+    "servers_databases_vulnerabilityAssessments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the vulnerability assessment."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseVulnerabilityAssessmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a database Vulnerability Assessment."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/vulnerabilityAssessments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/vulnerabilityAssessments"
+    },
+    "servers_databases_vulnerabilityAssessments_rules_baselines": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "master",
+                "default"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the vulnerability assessment rule baseline (default implies a baseline on a database level rule and master for server level rule)."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseVulnerabilityAssessmentRuleBaselineProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a database Vulnerability Assessment rule baseline."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/vulnerabilityAssessments/rules/baselines"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/rules/baselines"
+    },
+    "servers_dnsAliases": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the server DNS alias."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/dnsAliases"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/dnsAliases"
+    },
+    "servers_extendedAuditingSettings": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the blob auditing policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ExtendedServerBlobAuditingPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of an extended server blob auditing policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/extendedAuditingSettings"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/extendedAuditingSettings"
+    },
+    "servers_jobAgents": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the job agent to be created or updated."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/JobAgentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a job agent."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/servers_jobAgents_credentials_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_jobAgents_jobs_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_jobAgents_targetGroups_childResource"
+              }
+            ]
+          }
+        },
+        "sku": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Sku"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "An ARM Resource SKU."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/jobAgents"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/jobAgents"
+    },
+    "servers_jobAgents_credentials": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the credential."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/JobCredentialProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a job credential."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/jobAgents/credentials"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/jobAgents/credentials"
+    },
+    "servers_jobAgents_jobs": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the job to get."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/JobProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a job."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/servers_jobAgents_jobs_executions_childResource"
+              },
+              {
+                "$ref": "#/definitions/servers_jobAgents_jobs_steps_childResource"
+              }
+            ]
+          }
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/jobAgents/jobs"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/jobAgents/jobs"
+    },
+    "servers_jobAgents_jobs_executions": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The job execution id to create the job execution under."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/jobAgents/jobs/executions"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/jobAgents/jobs/executions"
+    },
+    "servers_jobAgents_jobs_steps": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the job step."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/JobStepProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a job step."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/jobAgents/jobs/steps"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/jobAgents/jobs/steps"
+    },
+    "servers_jobAgents_targetGroups": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the target group."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/JobTargetGroupProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of job target group."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/jobAgents/targetGroups"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/jobAgents/targetGroups"
+    },
+    "servers_securityAlertPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/Default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the threat detection policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SecurityAlertPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a security alert policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/securityAlertPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/securityAlertPolicies"
+    }
+  },
+  "definitions": {
+    "DatabaseBlobAuditingPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "auditActionsAndGroups": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the Actions-Groups and Actions to audit.\r\n\r\nThe recommended set of action groups to use is the following combination - this will audit all the queries and stored procedures executed against the database, as well as successful and failed logins:\r\n\r\nBATCH_COMPLETED_GROUP,\r\nSUCCESSFUL_DATABASE_AUTHENTICATION_GROUP,\r\nFAILED_DATABASE_AUTHENTICATION_GROUP.\r\n\r\nThis above combination is also the set that is configured by default when enabling auditing from the Azure portal.\r\n\r\nThe supported action groups to audit are (note: choose only specific groups that cover your auditing needs. Using unnecessary groups could lead to very large quantities of audit records):\r\n\r\nAPPLICATION_ROLE_CHANGE_PASSWORD_GROUP\r\nBACKUP_RESTORE_GROUP\r\nDATABASE_LOGOUT_GROUP\r\nDATABASE_OBJECT_CHANGE_GROUP\r\nDATABASE_OBJECT_OWNERSHIP_CHANGE_GROUP\r\nDATABASE_OBJECT_PERMISSION_CHANGE_GROUP\r\nDATABASE_OPERATION_GROUP\r\nDATABASE_PERMISSION_CHANGE_GROUP\r\nDATABASE_PRINCIPAL_CHANGE_GROUP\r\nDATABASE_PRINCIPAL_IMPERSONATION_GROUP\r\nDATABASE_ROLE_MEMBER_CHANGE_GROUP\r\nFAILED_DATABASE_AUTHENTICATION_GROUP\r\nSCHEMA_OBJECT_ACCESS_GROUP\r\nSCHEMA_OBJECT_CHANGE_GROUP\r\nSCHEMA_OBJECT_OWNERSHIP_CHANGE_GROUP\r\nSCHEMA_OBJECT_PERMISSION_CHANGE_GROUP\r\nSUCCESSFUL_DATABASE_AUTHENTICATION_GROUP\r\nUSER_CHANGE_PASSWORD_GROUP\r\nBATCH_STARTED_GROUP\r\nBATCH_COMPLETED_GROUP\r\n\r\nThese are groups that cover all sql statements and stored procedures executed against the database, and should not be used in combination with other groups as this will result in duplicate audit logs.\r\n\r\nFor more information, see [Database-Level Audit Action Groups](https://docs.microsoft.com/en-us/sql/relational-databases/security/auditing/sql-server-audit-action-groups-and-actions#database-level-audit-action-groups).\r\n\r\nFor Database auditing policy, specific Actions can also be specified (note that Actions cannot be specified for Server auditing policy). The supported actions to audit are:\r\nSELECT\r\nUPDATE\r\nINSERT\r\nDELETE\r\nEXECUTE\r\nRECEIVE\r\nREFERENCES\r\n\r\nThe general form for defining an action to be audited is:\r\n{action} ON {object} BY {principal}\r\n\r\nNote that <object> in the above format can refer to an object like a table, view, or stored procedure, or an entire database or schema. For the latter cases, the forms DATABASE::{db_name} and SCHEMA::{schema_name} are used, respectively.\r\n\r\nFor example:\r\nSELECT on dbo.myTable by public\r\nSELECT on DATABASE::myDatabase by public\r\nSELECT on SCHEMA::mySchema by public\r\n\r\nFor more information, see [Database-Level Audit Actions](https://docs.microsoft.com/en-us/sql/relational-databases/security/auditing/sql-server-audit-action-groups-and-actions#database-level-audit-actions)"
+        },
+        "isAzureMonitorTargetEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies whether audit events are sent to Azure Monitor. \r\nIn order to send the events to Azure Monitor, specify 'state' as 'Enabled' and 'isAzureMonitorTargetEnabled' as true.\r\n\r\nWhen using REST API to configure auditing, Diagnostic Settings with 'SQLSecurityAuditEvents' diagnostic logs category on the database should be also created.\r\nNote that for server level audit you should use the 'master' database as {databaseName}.\r\n\r\nDiagnostic Settings URI format:\r\nPUT https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/providers/microsoft.insights/diagnosticSettings/{settingsName}?api-version=2017-05-01-preview\r\n\r\nFor more information, see [Diagnostic Settings REST API](https://go.microsoft.com/fwlink/?linkid=2033207)\r\nor [Diagnostic Settings PowerShell](https://go.microsoft.com/fwlink/?linkid=2033043)\r\n"
+        },
+        "isStorageSecondaryKeyInUse": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies whether storageAccountAccessKey value is the storage's secondary key."
+        },
+        "retentionDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of days to keep in the audit logs in the storage account."
+        },
+        "state": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the state of the policy. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required."
+        },
+        "storageAccountAccessKey": {
+          "type": "string",
+          "description": "Specifies the identifier key of the auditing storage account. If state is Enabled and storageEndpoint is specified, storageAccountAccessKey is required."
+        },
+        "storageAccountSubscriptionId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the blob storage subscription Id."
+        },
+        "storageEndpoint": {
+          "type": "string",
+          "description": "Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). If state is Enabled, storageEndpoint is required."
+        }
+      },
+      "required": [
+        "state"
+      ],
+      "description": "Properties of a database blob auditing policy."
+    },
+    "DatabasePropertiesModel": {
+      "type": "object",
+      "properties": {
+        "catalogCollation": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "DATABASE_DEFAULT",
+                "SQL_Latin1_General_CP1_CI_AS"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Collation of the metadata catalog."
+        },
+        "collation": {
+          "type": "string",
+          "description": "The collation of the database."
+        },
+        "createMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Copy",
+                "Default",
+                "NonReadableSecondary",
+                "OnlineSecondary",
+                "PointInTimeRestore",
+                "Recovery",
+                "Restore",
+                "RestoreLongTermRetentionBackup",
+                "Secondary",
+                "RestoreExternalBackup",
+                "RestoreExternalBackupSecondary"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the mode of database creation.\r\n\r\nDefault: regular database creation.\r\n\r\nCopy: creates a database as a copy of an existing database. sourceDatabaseId must be specified as the resource ID of the source database.\r\n\r\nSecondary: creates a database as a secondary replica of an existing database. sourceDatabaseId must be specified as the resource ID of the existing primary database.\r\n\r\nPointInTimeRestore: Creates a database by restoring a point in time backup of an existing database. sourceDatabaseId must be specified as the resource ID of the existing database, and restorePointInTime must be specified.\r\n\r\nRecovery: Creates a database by restoring a geo-replicated backup. sourceDatabaseId must be specified as the recoverable database resource ID to restore.\r\n\r\nRestore: Creates a database by restoring a backup of a deleted database. sourceDatabaseId must be specified. If sourceDatabaseId is the database's original resource ID, then sourceDatabaseDeletionDate must be specified. Otherwise sourceDatabaseId must be the restorable dropped database resource ID and sourceDatabaseDeletionDate is ignored. restorePointInTime may also be specified to restore from an earlier point in time.\r\n\r\nRestoreLongTermRetentionBackup: Creates a database by restoring from a long term retention vault. recoveryServicesRecoveryPointResourceId must be specified as the recovery point resource ID.\r\n\r\nCopy, Secondary, and RestoreLongTermRetentionBackup are not supported for DataWarehouse edition."
+        },
+        "elasticPoolId": {
+          "type": "string",
+          "description": "The resource identifier of the elastic pool containing this database."
+        },
+        "longTermRetentionBackupResourceId": {
+          "type": "string",
+          "description": "The resource identifier of the long term retention backup associated with create operation of this database."
+        },
+        "maxSizeBytes": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The max size of the database expressed in bytes."
+        },
+        "recoverableDatabaseId": {
+          "type": "string",
+          "description": "The resource identifier of the recoverable database associated with create operation of this database."
+        },
+        "recoveryServicesRecoveryPointId": {
+          "type": "string",
+          "description": "The resource identifier of the recovery point associated with create operation of this database."
+        },
+        "restorableDroppedDatabaseId": {
+          "type": "string",
+          "description": "The resource identifier of the restorable dropped database associated with create operation of this database."
+        },
+        "restorePointInTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database."
+        },
+        "sampleName": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AdventureWorksLT",
+                "WideWorldImportersStd",
+                "WideWorldImportersFull"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the sample schema to apply when creating this database."
+        },
+        "sourceDatabaseDeletionDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specifies the time that the database was deleted."
+        },
+        "sourceDatabaseId": {
+          "type": "string",
+          "description": "The resource identifier of the source database associated with create operation of this database."
+        },
+        "zoneRedundant": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones."
+        }
+      },
+      "description": "The database's properties."
+    },
+    "DatabaseVulnerabilityAssessmentProperties": {
+      "type": "object",
+      "properties": {
+        "recurringScans": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/VulnerabilityAssessmentRecurringScansProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a Vulnerability Assessment recurring scans."
+        },
+        "storageAccountAccessKey": {
+          "type": "string",
+          "description": "Specifies the identifier key of the storage account for vulnerability assessment scan results. If 'StorageContainerSasKey' isn't specified, storageAccountAccessKey is required."
+        },
+        "storageContainerPath": {
+          "type": "string",
+          "description": "A blob storage container path to hold the scan results (e.g. https://myStorage.blob.core.windows.net/VaScans/).  It is required if server level vulnerability assessment policy doesn't set"
+        },
+        "storageContainerSasKey": {
+          "type": "string",
+          "description": "A shared access signature (SAS Key) that has write access to the blob container specified in 'storageContainerPath' parameter. If 'storageAccountAccessKey' isn't specified, StorageContainerSasKey is required."
+        }
+      },
+      "description": "Properties of a database Vulnerability Assessment."
+    },
+    "DatabaseVulnerabilityAssessmentRuleBaselineItem": {
+      "type": "object",
+      "properties": {
+        "result": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The rule baseline result"
+        }
+      },
+      "required": [
+        "result"
+      ],
+      "description": "Properties for an Azure SQL Database Vulnerability Assessment rule baseline's result."
+    },
+    "DatabaseVulnerabilityAssessmentRuleBaselineProperties": {
+      "type": "object",
+      "properties": {
+        "baselineResults": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DatabaseVulnerabilityAssessmentRuleBaselineItem"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The rule baseline result"
+        }
+      },
+      "required": [
+        "baselineResults"
+      ],
+      "description": "Properties of a database Vulnerability Assessment rule baseline."
+    },
+    "ExtendedDatabaseBlobAuditingPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "auditActionsAndGroups": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the Actions-Groups and Actions to audit.\r\n\r\nThe recommended set of action groups to use is the following combination - this will audit all the queries and stored procedures executed against the database, as well as successful and failed logins:\r\n\r\nBATCH_COMPLETED_GROUP,\r\nSUCCESSFUL_DATABASE_AUTHENTICATION_GROUP,\r\nFAILED_DATABASE_AUTHENTICATION_GROUP.\r\n\r\nThis above combination is also the set that is configured by default when enabling auditing from the Azure portal.\r\n\r\nThe supported action groups to audit are (note: choose only specific groups that cover your auditing needs. Using unnecessary groups could lead to very large quantities of audit records):\r\n\r\nAPPLICATION_ROLE_CHANGE_PASSWORD_GROUP\r\nBACKUP_RESTORE_GROUP\r\nDATABASE_LOGOUT_GROUP\r\nDATABASE_OBJECT_CHANGE_GROUP\r\nDATABASE_OBJECT_OWNERSHIP_CHANGE_GROUP\r\nDATABASE_OBJECT_PERMISSION_CHANGE_GROUP\r\nDATABASE_OPERATION_GROUP\r\nDATABASE_PERMISSION_CHANGE_GROUP\r\nDATABASE_PRINCIPAL_CHANGE_GROUP\r\nDATABASE_PRINCIPAL_IMPERSONATION_GROUP\r\nDATABASE_ROLE_MEMBER_CHANGE_GROUP\r\nFAILED_DATABASE_AUTHENTICATION_GROUP\r\nSCHEMA_OBJECT_ACCESS_GROUP\r\nSCHEMA_OBJECT_CHANGE_GROUP\r\nSCHEMA_OBJECT_OWNERSHIP_CHANGE_GROUP\r\nSCHEMA_OBJECT_PERMISSION_CHANGE_GROUP\r\nSUCCESSFUL_DATABASE_AUTHENTICATION_GROUP\r\nUSER_CHANGE_PASSWORD_GROUP\r\nBATCH_STARTED_GROUP\r\nBATCH_COMPLETED_GROUP\r\n\r\nThese are groups that cover all sql statements and stored procedures executed against the database, and should not be used in combination with other groups as this will result in duplicate audit logs.\r\n\r\nFor more information, see [Database-Level Audit Action Groups](https://docs.microsoft.com/en-us/sql/relational-databases/security/auditing/sql-server-audit-action-groups-and-actions#database-level-audit-action-groups).\r\n\r\nFor Database auditing policy, specific Actions can also be specified (note that Actions cannot be specified for Server auditing policy). The supported actions to audit are:\r\nSELECT\r\nUPDATE\r\nINSERT\r\nDELETE\r\nEXECUTE\r\nRECEIVE\r\nREFERENCES\r\n\r\nThe general form for defining an action to be audited is:\r\n{action} ON {object} BY {principal}\r\n\r\nNote that <object> in the above format can refer to an object like a table, view, or stored procedure, or an entire database or schema. For the latter cases, the forms DATABASE::{db_name} and SCHEMA::{schema_name} are used, respectively.\r\n\r\nFor example:\r\nSELECT on dbo.myTable by public\r\nSELECT on DATABASE::myDatabase by public\r\nSELECT on SCHEMA::mySchema by public\r\n\r\nFor more information, see [Database-Level Audit Actions](https://docs.microsoft.com/en-us/sql/relational-databases/security/auditing/sql-server-audit-action-groups-and-actions#database-level-audit-actions)"
+        },
+        "isAzureMonitorTargetEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies whether audit events are sent to Azure Monitor. \r\nIn order to send the events to Azure Monitor, specify 'state' as 'Enabled' and 'isAzureMonitorTargetEnabled' as true.\r\n\r\nWhen using REST API to configure auditing, Diagnostic Settings with 'SQLSecurityAuditEvents' diagnostic logs category on the database should be also created.\r\nNote that for server level audit you should use the 'master' database as {databaseName}.\r\n\r\nDiagnostic Settings URI format:\r\nPUT https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/providers/microsoft.insights/diagnosticSettings/{settingsName}?api-version=2017-05-01-preview\r\n\r\nFor more information, see [Diagnostic Settings REST API](https://go.microsoft.com/fwlink/?linkid=2033207)\r\nor [Diagnostic Settings PowerShell](https://go.microsoft.com/fwlink/?linkid=2033043)\r\n"
+        },
+        "isStorageSecondaryKeyInUse": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies whether storageAccountAccessKey value is the storage's secondary key."
+        },
+        "predicateExpression": {
+          "type": "string",
+          "description": "Specifies condition of where clause when creating an audit."
+        },
+        "retentionDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of days to keep in the audit logs in the storage account."
+        },
+        "state": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the state of the policy. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required."
+        },
+        "storageAccountAccessKey": {
+          "type": "string",
+          "description": "Specifies the identifier key of the auditing storage account. If state is Enabled and storageEndpoint is specified, storageAccountAccessKey is required."
+        },
+        "storageAccountSubscriptionId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the blob storage subscription Id."
+        },
+        "storageEndpoint": {
+          "type": "string",
+          "description": "Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). If state is Enabled, storageEndpoint is required."
+        }
+      },
+      "required": [
+        "state"
+      ],
+      "description": "Properties of an extended database blob auditing policy."
+    },
+    "ExtendedServerBlobAuditingPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "auditActionsAndGroups": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the Actions-Groups and Actions to audit.\r\n\r\nThe recommended set of action groups to use is the following combination - this will audit all the queries and stored procedures executed against the database, as well as successful and failed logins:\r\n\r\nBATCH_COMPLETED_GROUP,\r\nSUCCESSFUL_DATABASE_AUTHENTICATION_GROUP,\r\nFAILED_DATABASE_AUTHENTICATION_GROUP.\r\n\r\nThis above combination is also the set that is configured by default when enabling auditing from the Azure portal.\r\n\r\nThe supported action groups to audit are (note: choose only specific groups that cover your auditing needs. Using unnecessary groups could lead to very large quantities of audit records):\r\n\r\nAPPLICATION_ROLE_CHANGE_PASSWORD_GROUP\r\nBACKUP_RESTORE_GROUP\r\nDATABASE_LOGOUT_GROUP\r\nDATABASE_OBJECT_CHANGE_GROUP\r\nDATABASE_OBJECT_OWNERSHIP_CHANGE_GROUP\r\nDATABASE_OBJECT_PERMISSION_CHANGE_GROUP\r\nDATABASE_OPERATION_GROUP\r\nDATABASE_PERMISSION_CHANGE_GROUP\r\nDATABASE_PRINCIPAL_CHANGE_GROUP\r\nDATABASE_PRINCIPAL_IMPERSONATION_GROUP\r\nDATABASE_ROLE_MEMBER_CHANGE_GROUP\r\nFAILED_DATABASE_AUTHENTICATION_GROUP\r\nSCHEMA_OBJECT_ACCESS_GROUP\r\nSCHEMA_OBJECT_CHANGE_GROUP\r\nSCHEMA_OBJECT_OWNERSHIP_CHANGE_GROUP\r\nSCHEMA_OBJECT_PERMISSION_CHANGE_GROUP\r\nSUCCESSFUL_DATABASE_AUTHENTICATION_GROUP\r\nUSER_CHANGE_PASSWORD_GROUP\r\nBATCH_STARTED_GROUP\r\nBATCH_COMPLETED_GROUP\r\n\r\nThese are groups that cover all sql statements and stored procedures executed against the database, and should not be used in combination with other groups as this will result in duplicate audit logs.\r\n\r\nFor more information, see [Database-Level Audit Action Groups](https://docs.microsoft.com/en-us/sql/relational-databases/security/auditing/sql-server-audit-action-groups-and-actions#database-level-audit-action-groups).\r\n\r\nFor Database auditing policy, specific Actions can also be specified (note that Actions cannot be specified for Server auditing policy). The supported actions to audit are:\r\nSELECT\r\nUPDATE\r\nINSERT\r\nDELETE\r\nEXECUTE\r\nRECEIVE\r\nREFERENCES\r\n\r\nThe general form for defining an action to be audited is:\r\n{action} ON {object} BY {principal}\r\n\r\nNote that <object> in the above format can refer to an object like a table, view, or stored procedure, or an entire database or schema. For the latter cases, the forms DATABASE::{db_name} and SCHEMA::{schema_name} are used, respectively.\r\n\r\nFor example:\r\nSELECT on dbo.myTable by public\r\nSELECT on DATABASE::myDatabase by public\r\nSELECT on SCHEMA::mySchema by public\r\n\r\nFor more information, see [Database-Level Audit Actions](https://docs.microsoft.com/en-us/sql/relational-databases/security/auditing/sql-server-audit-action-groups-and-actions#database-level-audit-actions)"
+        },
+        "isAzureMonitorTargetEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies whether audit events are sent to Azure Monitor. \r\nIn order to send the events to Azure Monitor, specify 'state' as 'Enabled' and 'isAzureMonitorTargetEnabled' as true.\r\n\r\nWhen using REST API to configure auditing, Diagnostic Settings with 'SQLSecurityAuditEvents' diagnostic logs category on the database should be also created.\r\nNote that for server level audit you should use the 'master' database as {databaseName}.\r\n\r\nDiagnostic Settings URI format:\r\nPUT https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/providers/microsoft.insights/diagnosticSettings/{settingsName}?api-version=2017-05-01-preview\r\n\r\nFor more information, see [Diagnostic Settings REST API](https://go.microsoft.com/fwlink/?linkid=2033207)\r\nor [Diagnostic Settings PowerShell](https://go.microsoft.com/fwlink/?linkid=2033043)\r\n"
+        },
+        "isStorageSecondaryKeyInUse": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies whether storageAccountAccessKey value is the storage's secondary key."
+        },
+        "predicateExpression": {
+          "type": "string",
+          "description": "Specifies condition of where clause when creating an audit."
+        },
+        "retentionDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of days to keep in the audit logs in the storage account."
+        },
+        "state": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the state of the policy. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required."
+        },
+        "storageAccountAccessKey": {
+          "type": "string",
+          "description": "Specifies the identifier key of the auditing storage account. If state is Enabled and storageEndpoint is specified, storageAccountAccessKey is required."
+        },
+        "storageAccountSubscriptionId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the blob storage subscription Id."
+        },
+        "storageEndpoint": {
+          "type": "string",
+          "description": "Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). If state is Enabled, storageEndpoint is required."
+        }
+      },
+      "required": [
+        "state"
+      ],
+      "description": "Properties of an extended server blob auditing policy."
+    },
+    "JobAgentProperties": {
+      "type": "object",
+      "properties": {
+        "databaseId": {
+          "type": "string",
+          "description": "Resource ID of the database to store job metadata in."
+        }
+      },
+      "required": [
+        "databaseId"
+      ],
+      "description": "Properties of a job agent."
+    },
+    "JobCredentialProperties": {
+      "type": "object",
+      "properties": {
+        "password": {
+          "type": "string",
+          "description": "The credential password."
+        },
+        "username": {
+          "type": "string",
+          "description": "The credential user name."
+        }
+      },
+      "required": [
+        "password",
+        "username"
+      ],
+      "description": "Properties of a job credential."
+    },
+    "JobProperties": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "default": "",
+          "description": "User-defined description of the job."
+        },
+        "schedule": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/JobSchedule"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Scheduling properties of a job."
+        }
+      },
+      "description": "Properties of a job."
+    },
+    "JobSchedule": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether or not the schedule is enabled."
+        },
+        "endTime": {
+          "type": "string",
+          "default": "9999-12-31T11:59:59Z",
+          "format": "date-time",
+          "description": "Schedule end time."
+        },
+        "interval": {
+          "type": "string",
+          "description": "Value of the schedule's recurring interval, if the schedule type is recurring. ISO8601 duration format."
+        },
+        "startTime": {
+          "type": "string",
+          "default": "0001-01-01T00:00:00Z",
+          "format": "date-time",
+          "description": "Schedule start time."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Once",
+                "Recurring"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Schedule interval type."
+        }
+      },
+      "description": "Scheduling properties of a job."
+    },
+    "JobStepAction": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Inline"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The source of the action to execute."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "TSql"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Type of action being executed by the job step."
+        },
+        "value": {
+          "type": "string",
+          "description": "The action value, for example the text of the T-SQL script to execute."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "description": "The action to be executed by a job step."
+    },
+    "JobStepExecutionOptions": {
+      "type": "object",
+      "properties": {
+        "initialRetryIntervalSeconds": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "default": "1"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Initial delay between retries for job step execution."
+        },
+        "maximumRetryIntervalSeconds": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "default": "120"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum amount of time to wait between retries for job step execution."
+        },
+        "retryAttempts": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "default": "10"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Maximum number of times the job step will be reattempted if the first attempt fails."
+        },
+        "retryIntervalBackoffMultiplier": {
+          "oneOf": [
+            {
+              "type": "number",
+              "default": 2.0
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The backoff multiplier for the time between retries."
+        },
+        "timeoutSeconds": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "default": "43200"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Execution timeout for the job step."
+        }
+      },
+      "description": "The execution options of a job step."
+    },
+    "JobStepOutput": {
+      "type": "object",
+      "properties": {
+        "credential": {
+          "type": "string",
+          "description": "The resource ID of the credential to use to connect to the output destination."
+        },
+        "databaseName": {
+          "type": "string",
+          "description": "The output destination database."
+        },
+        "resourceGroupName": {
+          "type": "string",
+          "description": "The output destination resource group."
+        },
+        "schemaName": {
+          "type": "string",
+          "default": "dbo",
+          "description": "The output destination schema."
+        },
+        "serverName": {
+          "type": "string",
+          "description": "The output destination server name."
+        },
+        "subscriptionId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The output destination subscription id."
+        },
+        "tableName": {
+          "type": "string",
+          "description": "The output destination table."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "SqlDatabase"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The output destination type."
+        }
+      },
+      "required": [
+        "credential",
+        "databaseName",
+        "serverName",
+        "tableName"
+      ],
+      "description": "The output configuration of a job step."
+    },
+    "JobStepProperties": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/JobStepAction"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The action to be executed by a job step."
+        },
+        "credential": {
+          "type": "string",
+          "description": "The resource ID of the job credential that will be used to connect to the targets."
+        },
+        "executionOptions": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/JobStepExecutionOptions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The execution options of a job step."
+        },
+        "output": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/JobStepOutput"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The output configuration of a job step."
+        },
+        "stepId": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The job step's index within the job. If not specified when creating the job step, it will be created as the last step. If not specified when updating the job step, the step id is not modified."
+        },
+        "targetGroup": {
+          "type": "string",
+          "description": "The resource ID of the target group that the job step will be executed on."
+        }
+      },
+      "required": [
+        "action",
+        "credential",
+        "targetGroup"
+      ],
+      "description": "Properties of a job step."
+    },
+    "JobTarget": {
+      "type": "object",
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "The target database name."
+        },
+        "elasticPoolName": {
+          "type": "string",
+          "description": "The target elastic pool name."
+        },
+        "membershipType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Include",
+                "Exclude"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether the target is included or excluded from the group."
+        },
+        "refreshCredential": {
+          "type": "string",
+          "description": "The resource ID of the credential that is used during job execution to connect to the target and determine the list of databases inside the target."
+        },
+        "serverName": {
+          "type": "string",
+          "description": "The target server name."
+        },
+        "shardMapName": {
+          "type": "string",
+          "description": "The target shard map."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "TargetGroup",
+                "SqlDatabase",
+                "SqlElasticPool",
+                "SqlShardMap",
+                "SqlServer"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The target type."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "description": "A job target, for example a specific database or a container of databases that is evaluated during job execution."
+    },
+    "JobTargetGroupProperties": {
+      "type": "object",
+      "properties": {
+        "members": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/JobTarget"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Members of the target group."
+        }
+      },
+      "required": [
+        "members"
+      ],
+      "description": "Properties of job target group."
+    },
+    "LongTermRetentionPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "monthlyRetention": {
+          "type": "string",
+          "description": "The monthly retention policy for an LTR backup in an ISO 8601 format."
+        },
+        "weeklyRetention": {
+          "type": "string",
+          "description": "The weekly retention policy for an LTR backup in an ISO 8601 format."
+        },
+        "weekOfYear": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The week of year to take the yearly backup in an ISO 8601 format."
+        },
+        "yearlyRetention": {
+          "type": "string",
+          "description": "The yearly retention policy for an LTR backup in an ISO 8601 format."
+        }
+      },
+      "description": "Properties of a long term retention policy"
+    },
+    "ManagedBackupShortTermRetentionPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "retentionDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The backup retention period in days. This is how many days Point-in-Time Restore will be supported."
+        }
+      },
+      "description": "Properties of a short term retention policy"
+    },
+    "ManagedDatabaseProperties": {
+      "type": "object",
+      "properties": {
+        "catalogCollation": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "DATABASE_DEFAULT",
+                "SQL_Latin1_General_CP1_CI_AS"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Collation of the metadata catalog."
+        },
+        "collation": {
+          "type": "string",
+          "description": "Collation of the managed database."
+        },
+        "createMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Default",
+                "RestoreExternalBackup",
+                "PointInTimeRestore",
+                "Recovery"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Managed database create mode. PointInTimeRestore: Create a database by restoring a point in time backup of an existing database. SourceDatabaseName, SourceManagedInstanceName and PointInTime must be specified. RestoreExternalBackup: Create a database by restoring from external backup files. Collation, StorageContainerUri and StorageContainerSasToken must be specified. Recovery: Creates a database by restoring a geo-replicated backup. RecoverableDatabaseId must be specified as the recoverable database resource ID to restore."
+        },
+        "recoverableDatabaseId": {
+          "type": "string",
+          "description": "The resource identifier of the recoverable database associated with create operation of this database."
+        },
+        "restorableDroppedDatabaseId": {
+          "type": "string",
+          "description": "The restorable dropped database resource id to restore when creating this database."
+        },
+        "restorePointInTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Conditional. If createMode is PointInTimeRestore, this value is required. Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database."
+        },
+        "sourceDatabaseId": {
+          "type": "string",
+          "description": "The resource identifier of the source database associated with create operation of this database."
+        },
+        "storageContainerSasToken": {
+          "type": "string",
+          "description": "Conditional. If createMode is RestoreExternalBackup, this value is required. Specifies the storage container sas token."
+        },
+        "storageContainerUri": {
+          "type": "string",
+          "description": "Conditional. If createMode is RestoreExternalBackup, this value is required. Specifies the uri of the storage container where backups for this restore are stored."
+        }
+      },
+      "description": "The managed database's properties."
+    },
+    "ManagedInstanceAdministratorProperties": {
+      "type": "object",
+      "properties": {
+        "administratorType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "ActiveDirectory"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Type of the managed instance administrator."
+        },
+        "login": {
+          "type": "string",
+          "description": "Login name of the managed instance administrator."
+        },
+        "sid": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "SID (object ID) of the managed instance administrator."
+        },
+        "tenantId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Tenant ID of the managed instance administrator."
+        }
+      },
+      "required": [
+        "administratorType",
+        "login",
+        "sid"
+      ],
+      "description": "The properties of a managed instance administrator."
+    },
+    "managedInstances_databases_backupShortTermRetentionPolicies_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ],
+          "description": "The policy name. Should always be \"default\"."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedBackupShortTermRetentionPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a short term retention policy"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "backupShortTermRetentionPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/databases/backupShortTermRetentionPolicies"
+    },
+    "managedInstances_databases_securityAlertPolicies_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "Default"
+          ],
+          "description": "The name of the security alert policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SecurityAlertPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a security alert policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "securityAlertPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/databases/securityAlertPolicies"
+    },
+    "SecurityAlertPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "disabledAlerts": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies an array of alerts that are disabled. Allowed values are: Sql_Injection, Sql_Injection_Vulnerability, Access_Anomaly, Data_Exfiltration, Unsafe_Action"
+        },
+        "emailAccountAdmins": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies that the alert is sent to the account administrators."
+        },
+        "emailAddresses": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies an array of e-mail addresses to which the alert is sent."
+        },
+        "retentionDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of days to keep in the Threat Detection audit logs."
+        },
+        "state": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "New",
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the state of the policy, whether it is enabled or disabled or a policy has not been applied yet on the specific database."
+        },
+        "storageAccountAccessKey": {
+          "type": "string",
+          "description": "Specifies the identifier key of the Threat Detection audit storage account."
+        },
+        "storageEndpoint": {
+          "type": "string",
+          "description": "Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all Threat Detection audit logs."
+        }
+      },
+      "required": [
+        "state"
+      ],
+      "description": "Properties of a security alert policy."
+    },
+    "SensitivityLabelProperties": {
+      "type": "object",
+      "properties": {
+        "informationType": {
+          "type": "string",
+          "description": "The information type."
+        },
+        "informationTypeId": {
+          "type": "string",
+          "description": "The information type ID."
+        },
+        "labelId": {
+          "type": "string",
+          "description": "The label ID."
+        },
+        "labelName": {
+          "type": "string",
+          "description": "The label name."
+        }
+      },
+      "description": "Properties of a sensitivity label."
+    },
+    "ServerBlobAuditingPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "auditActionsAndGroups": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the Actions-Groups and Actions to audit.\r\n\r\nThe recommended set of action groups to use is the following combination - this will audit all the queries and stored procedures executed against the database, as well as successful and failed logins:\r\n\r\nBATCH_COMPLETED_GROUP,\r\nSUCCESSFUL_DATABASE_AUTHENTICATION_GROUP,\r\nFAILED_DATABASE_AUTHENTICATION_GROUP.\r\n\r\nThis above combination is also the set that is configured by default when enabling auditing from the Azure portal.\r\n\r\nThe supported action groups to audit are (note: choose only specific groups that cover your auditing needs. Using unnecessary groups could lead to very large quantities of audit records):\r\n\r\nAPPLICATION_ROLE_CHANGE_PASSWORD_GROUP\r\nBACKUP_RESTORE_GROUP\r\nDATABASE_LOGOUT_GROUP\r\nDATABASE_OBJECT_CHANGE_GROUP\r\nDATABASE_OBJECT_OWNERSHIP_CHANGE_GROUP\r\nDATABASE_OBJECT_PERMISSION_CHANGE_GROUP\r\nDATABASE_OPERATION_GROUP\r\nDATABASE_PERMISSION_CHANGE_GROUP\r\nDATABASE_PRINCIPAL_CHANGE_GROUP\r\nDATABASE_PRINCIPAL_IMPERSONATION_GROUP\r\nDATABASE_ROLE_MEMBER_CHANGE_GROUP\r\nFAILED_DATABASE_AUTHENTICATION_GROUP\r\nSCHEMA_OBJECT_ACCESS_GROUP\r\nSCHEMA_OBJECT_CHANGE_GROUP\r\nSCHEMA_OBJECT_OWNERSHIP_CHANGE_GROUP\r\nSCHEMA_OBJECT_PERMISSION_CHANGE_GROUP\r\nSUCCESSFUL_DATABASE_AUTHENTICATION_GROUP\r\nUSER_CHANGE_PASSWORD_GROUP\r\nBATCH_STARTED_GROUP\r\nBATCH_COMPLETED_GROUP\r\n\r\nThese are groups that cover all sql statements and stored procedures executed against the database, and should not be used in combination with other groups as this will result in duplicate audit logs.\r\n\r\nFor more information, see [Database-Level Audit Action Groups](https://docs.microsoft.com/en-us/sql/relational-databases/security/auditing/sql-server-audit-action-groups-and-actions#database-level-audit-action-groups).\r\n\r\nFor Database auditing policy, specific Actions can also be specified (note that Actions cannot be specified for Server auditing policy). The supported actions to audit are:\r\nSELECT\r\nUPDATE\r\nINSERT\r\nDELETE\r\nEXECUTE\r\nRECEIVE\r\nREFERENCES\r\n\r\nThe general form for defining an action to be audited is:\r\n{action} ON {object} BY {principal}\r\n\r\nNote that <object> in the above format can refer to an object like a table, view, or stored procedure, or an entire database or schema. For the latter cases, the forms DATABASE::{db_name} and SCHEMA::{schema_name} are used, respectively.\r\n\r\nFor example:\r\nSELECT on dbo.myTable by public\r\nSELECT on DATABASE::myDatabase by public\r\nSELECT on SCHEMA::mySchema by public\r\n\r\nFor more information, see [Database-Level Audit Actions](https://docs.microsoft.com/en-us/sql/relational-databases/security/auditing/sql-server-audit-action-groups-and-actions#database-level-audit-actions)"
+        },
+        "isAzureMonitorTargetEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies whether audit events are sent to Azure Monitor. \r\nIn order to send the events to Azure Monitor, specify 'state' as 'Enabled' and 'isAzureMonitorTargetEnabled' as true.\r\n\r\nWhen using REST API to configure auditing, Diagnostic Settings with 'SQLSecurityAuditEvents' diagnostic logs category on the database should be also created.\r\nNote that for server level audit you should use the 'master' database as {databaseName}.\r\n\r\nDiagnostic Settings URI format:\r\nPUT https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/providers/microsoft.insights/diagnosticSettings/{settingsName}?api-version=2017-05-01-preview\r\n\r\nFor more information, see [Diagnostic Settings REST API](https://go.microsoft.com/fwlink/?linkid=2033207)\r\nor [Diagnostic Settings PowerShell](https://go.microsoft.com/fwlink/?linkid=2033043)\r\n"
+        },
+        "isStorageSecondaryKeyInUse": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies whether storageAccountAccessKey value is the storage's secondary key."
+        },
+        "retentionDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of days to keep in the audit logs in the storage account."
+        },
+        "state": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the state of the policy. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required."
+        },
+        "storageAccountAccessKey": {
+          "type": "string",
+          "description": "Specifies the identifier key of the auditing storage account. If state is Enabled and storageEndpoint is specified, storageAccountAccessKey is required."
+        },
+        "storageAccountSubscriptionId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the blob storage subscription Id."
+        },
+        "storageEndpoint": {
+          "type": "string",
+          "description": "Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). If state is Enabled, storageEndpoint is required."
+        }
+      },
+      "required": [
+        "state"
+      ],
+      "description": "Properties of a server blob auditing policy."
+    },
+    "servers_databases_auditingSettings_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ],
+          "description": "The name of the blob auditing policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseBlobAuditingPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a database blob auditing policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "auditingSettings"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/auditingSettings"
+    },
+    "servers_databases_backupLongTermRetentionPolicies_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ],
+          "description": "The policy name. Should always be Default."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/LongTermRetentionPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a long term retention policy"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "backupLongTermRetentionPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies"
+    },
+    "servers_databases_extendedAuditingSettings_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ],
+          "description": "The name of the blob auditing policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ExtendedDatabaseBlobAuditingPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of an extended database blob auditing policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "extendedAuditingSettings"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/extendedAuditingSettings"
+    },
+    "servers_databases_vulnerabilityAssessments_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ],
+          "description": "The name of the vulnerability assessment."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseVulnerabilityAssessmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a database Vulnerability Assessment."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "vulnerabilityAssessments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/vulnerabilityAssessments"
+    },
+    "servers_jobAgents_credentials_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the credential."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/JobCredentialProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a job credential."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "credentials"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/jobAgents/credentials"
+    },
+    "servers_jobAgents_jobs_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the job to get."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/JobProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a job."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "jobs"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/jobAgents/jobs"
+    },
+    "servers_jobAgents_jobs_executions_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The job execution id to create the job execution under."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "executions"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/jobAgents/jobs/executions"
+    },
+    "servers_jobAgents_jobs_steps_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the job step."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/JobStepProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a job step."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "steps"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/jobAgents/jobs/steps"
+    },
+    "servers_jobAgents_targetGroups_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the target group."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/JobTargetGroupProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of job target group."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "targetGroups"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/jobAgents/targetGroups"
+    },
+    "Sku": {
+      "type": "object",
+      "properties": {
+        "capacity": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Capacity of the particular SKU."
+        },
+        "family": {
+          "type": "string",
+          "description": "If the service has different generations of hardware, for the same SKU, then that can be captured here."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the SKU, typically, a letter + Number code, e.g. P3."
+        },
+        "size": {
+          "type": "string",
+          "description": "Size of the particular SKU"
+        },
+        "tier": {
+          "type": "string",
+          "description": "The tier or edition of the particular SKU, e.g. Basic, Premium."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "description": "An ARM Resource SKU."
+    },
+    "VulnerabilityAssessmentRecurringScansProperties": {
+      "type": "object",
+      "properties": {
+        "emails": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies an array of e-mail addresses to which the scan notification is sent."
+        },
+        "emailSubscriptionAdmins": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "default": true
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies that the schedule scan notification will be is sent to the subscription administrators."
+        },
+        "isEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurring scans state."
+        }
+      },
+      "description": "Properties of a Vulnerability Assessment recurring scans."
+    }
+  }
+}

--- a/test/Resource/Expected/Microsoft.Sql/2017-10-01-preview/Microsoft.Sql.json
+++ b/test/Resource/Expected/Microsoft.Sql/2017-10-01-preview/Microsoft.Sql.json
@@ -1,0 +1,1103 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2017-10-01-preview/Microsoft.Sql.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Sql",
+  "description": "Microsoft Sql Resource Types",
+  "resourceDefinitions": {
+    "locations_instanceFailoverGroups": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-10-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the failover group."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/InstanceFailoverGroupProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a instance failover group."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/locations/instanceFailoverGroups"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/locations/instanceFailoverGroups"
+    },
+    "managedInstances_databases_vulnerabilityAssessments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-10-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the vulnerability assessment."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseVulnerabilityAssessmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a database Vulnerability Assessment."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments"
+    },
+    "managedInstances_databases_vulnerabilityAssessments_rules_baselines": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-10-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "master",
+                "default"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the vulnerability assessment rule baseline (default implies a baseline on a database level rule and master for server level rule)."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseVulnerabilityAssessmentRuleBaselineProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a database Vulnerability Assessment rule baseline."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments/rules/baselines"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments/rules/baselines"
+    },
+    "managedInstances_encryptionProtector": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-10-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/current$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the encryption protector to be updated."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedInstanceEncryptionProtectorProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for an encryption protector execution."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances/encryptionProtector"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/encryptionProtector"
+    },
+    "managedInstances_keys": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-10-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the managed instance key to be operated on (updated or created)."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedInstanceKeyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for a key execution."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances/keys"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/keys"
+    },
+    "servers_databases": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-10-01-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the database."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DatabaseProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/servers_databases_backupShortTermRetentionPolicies_childResource"
+              }
+            ]
+          }
+        },
+        "sku": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Sku"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "An ARM Resource SKU."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases"
+    },
+    "servers_databases_backupShortTermRetentionPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-10-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The policy name. Should always be \"default\"."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/BackupShortTermRetentionPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a short term retention policy"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies"
+    },
+    "servers_elasticPools": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-10-01-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the elastic pool."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ElasticPoolProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of an elastic pool"
+        },
+        "sku": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Sku"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "An ARM Resource SKU."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/elasticPools"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/elasticPools"
+    }
+  },
+  "definitions": {
+    "BackupShortTermRetentionPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "retentionDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The backup retention period in days. This is how many days Point-in-Time Restore will be supported."
+        }
+      },
+      "description": "Properties of a short term retention policy"
+    },
+    "DatabaseProperties": {
+      "type": "object",
+      "properties": {
+        "autoPauseDelay": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled"
+        },
+        "catalogCollation": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "DATABASE_DEFAULT",
+                "SQL_Latin1_General_CP1_CI_AS"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Collation of the metadata catalog."
+        },
+        "collation": {
+          "type": "string",
+          "description": "The collation of the database."
+        },
+        "createMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Copy",
+                "Default",
+                "NonReadableSecondary",
+                "OnlineSecondary",
+                "PointInTimeRestore",
+                "Recovery",
+                "Restore",
+                "RestoreLongTermRetentionBackup",
+                "Secondary",
+                "RestoreExternalBackup",
+                "RestoreExternalBackupSecondary"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the mode of database creation.\r\n\r\nDefault: regular database creation.\r\n\r\nCopy: creates a database as a copy of an existing database. sourceDatabaseId must be specified as the resource ID of the source database.\r\n\r\nSecondary: creates a database as a secondary replica of an existing database. sourceDatabaseId must be specified as the resource ID of the existing primary database.\r\n\r\nPointInTimeRestore: Creates a database by restoring a point in time backup of an existing database. sourceDatabaseId must be specified as the resource ID of the existing database, and restorePointInTime must be specified.\r\n\r\nRecovery: Creates a database by restoring a geo-replicated backup. sourceDatabaseId must be specified as the recoverable database resource ID to restore.\r\n\r\nRestore: Creates a database by restoring a backup of a deleted database. sourceDatabaseId must be specified. If sourceDatabaseId is the database's original resource ID, then sourceDatabaseDeletionDate must be specified. Otherwise sourceDatabaseId must be the restorable dropped database resource ID and sourceDatabaseDeletionDate is ignored. restorePointInTime may also be specified to restore from an earlier point in time.\r\n\r\nRestoreLongTermRetentionBackup: Creates a database by restoring from a long term retention vault. recoveryServicesRecoveryPointResourceId must be specified as the recovery point resource ID.\r\n\r\nCopy, Secondary, and RestoreLongTermRetentionBackup are not supported for DataWarehouse edition."
+        },
+        "elasticPoolId": {
+          "type": "string",
+          "description": "The resource identifier of the elastic pool containing this database."
+        },
+        "licenseType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "LicenseIncluded",
+                "BasePrice"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The license type to apply for this database."
+        },
+        "longTermRetentionBackupResourceId": {
+          "type": "string",
+          "description": "The resource identifier of the long term retention backup associated with create operation of this database."
+        },
+        "maxSizeBytes": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The max size of the database expressed in bytes."
+        },
+        "minCapacity": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Minimal capacity that database will always have allocated, if not paused"
+        },
+        "readReplicaCount": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The number of readonly secondary replicas associated with the database to which readonly application intent connections may be routed. This property is only settable for Hyperscale edition databases."
+        },
+        "readScale": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "If enabled, connections that have application intent set to readonly in their connection string may be routed to a readonly secondary replica. This property is only settable for Premium and Business Critical databases."
+        },
+        "recoverableDatabaseId": {
+          "type": "string",
+          "description": "The resource identifier of the recoverable database associated with create operation of this database."
+        },
+        "recoveryServicesRecoveryPointId": {
+          "type": "string",
+          "description": "The resource identifier of the recovery point associated with create operation of this database."
+        },
+        "restorableDroppedDatabaseId": {
+          "type": "string",
+          "description": "The resource identifier of the restorable dropped database associated with create operation of this database."
+        },
+        "restorePointInTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database."
+        },
+        "sampleName": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AdventureWorksLT",
+                "WideWorldImportersStd",
+                "WideWorldImportersFull"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the sample schema to apply when creating this database."
+        },
+        "sourceDatabaseDeletionDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specifies the time that the database was deleted."
+        },
+        "sourceDatabaseId": {
+          "type": "string",
+          "description": "The resource identifier of the source database associated with create operation of this database."
+        },
+        "zoneRedundant": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones."
+        }
+      }
+    },
+    "DatabaseVulnerabilityAssessmentProperties": {
+      "type": "object",
+      "properties": {
+        "recurringScans": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/VulnerabilityAssessmentRecurringScansProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a Vulnerability Assessment recurring scans."
+        },
+        "storageAccountAccessKey": {
+          "type": "string",
+          "description": "Specifies the identifier key of the storage account for vulnerability assessment scan results. If 'StorageContainerSasKey' isn't specified, storageAccountAccessKey is required."
+        },
+        "storageContainerPath": {
+          "type": "string",
+          "description": "A blob storage container path to hold the scan results (e.g. https://myStorage.blob.core.windows.net/VaScans/).  It is required if server level vulnerability assessment policy doesn't set"
+        },
+        "storageContainerSasKey": {
+          "type": "string",
+          "description": "A shared access signature (SAS Key) that has write access to the blob container specified in 'storageContainerPath' parameter. If 'storageAccountAccessKey' isn't specified, StorageContainerSasKey is required."
+        }
+      },
+      "description": "Properties of a database Vulnerability Assessment."
+    },
+    "DatabaseVulnerabilityAssessmentRuleBaselineItem": {
+      "type": "object",
+      "properties": {
+        "result": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The rule baseline result"
+        }
+      },
+      "required": [
+        "result"
+      ],
+      "description": "Properties for an Azure SQL Database Vulnerability Assessment rule baseline's result."
+    },
+    "DatabaseVulnerabilityAssessmentRuleBaselineProperties": {
+      "type": "object",
+      "properties": {
+        "baselineResults": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DatabaseVulnerabilityAssessmentRuleBaselineItem"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The rule baseline result"
+        }
+      },
+      "required": [
+        "baselineResults"
+      ],
+      "description": "Properties of a database Vulnerability Assessment rule baseline."
+    },
+    "ElasticPoolPerDatabaseSettings": {
+      "type": "object",
+      "properties": {
+        "maxCapacity": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum capacity any one database can consume."
+        },
+        "minCapacity": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The minimum capacity all databases are guaranteed."
+        }
+      },
+      "description": "Per database settings of an elastic pool."
+    },
+    "ElasticPoolProperties": {
+      "type": "object",
+      "properties": {
+        "licenseType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "LicenseIncluded",
+                "BasePrice"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The license type to apply for this elastic pool."
+        },
+        "maxSizeBytes": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The storage limit for the database elastic pool in bytes."
+        },
+        "perDatabaseSettings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ElasticPoolPerDatabaseSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Per database settings of an elastic pool."
+        },
+        "zoneRedundant": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones."
+        }
+      },
+      "description": "Properties of an elastic pool"
+    },
+    "InstanceFailoverGroupProperties": {
+      "type": "object",
+      "properties": {
+        "managedInstancePairs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ManagedInstancePairInfo"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of managed instance pairs in the failover group."
+        },
+        "partnerRegions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PartnerRegionInfo"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Partner region information for the failover group."
+        },
+        "readOnlyEndpoint": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/InstanceFailoverGroupReadOnlyEndpoint"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Read-only endpoint of the failover group instance."
+        },
+        "readWriteEndpoint": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/InstanceFailoverGroupReadWriteEndpoint"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Read-write endpoint of the failover group instance."
+        }
+      },
+      "required": [
+        "managedInstancePairs",
+        "partnerRegions",
+        "readWriteEndpoint"
+      ],
+      "description": "Properties of a instance failover group."
+    },
+    "InstanceFailoverGroupReadOnlyEndpoint": {
+      "type": "object",
+      "properties": {
+        "failoverPolicy": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Disabled",
+                "Enabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Failover policy of the read-only endpoint for the failover group."
+        }
+      },
+      "description": "Read-only endpoint of the failover group instance."
+    },
+    "InstanceFailoverGroupReadWriteEndpoint": {
+      "type": "object",
+      "properties": {
+        "failoverPolicy": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Manual",
+                "Automatic"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Failover policy of the read-write endpoint for the failover group. If failoverPolicy is Automatic then failoverWithDataLossGracePeriodMinutes is required."
+        },
+        "failoverWithDataLossGracePeriodMinutes": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Grace period before failover with data loss is attempted for the read-write endpoint. If failoverPolicy is Automatic then failoverWithDataLossGracePeriodMinutes is required."
+        }
+      },
+      "required": [
+        "failoverPolicy"
+      ],
+      "description": "Read-write endpoint of the failover group instance."
+    },
+    "ManagedInstanceEncryptionProtectorProperties": {
+      "type": "object",
+      "properties": {
+        "serverKeyName": {
+          "type": "string",
+          "description": "The name of the managed instance key."
+        },
+        "serverKeyType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "ServiceManaged",
+                "AzureKeyVault"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The encryption protector type like 'ServiceManaged', 'AzureKeyVault'."
+        }
+      },
+      "required": [
+        "serverKeyType"
+      ],
+      "description": "Properties for an encryption protector execution."
+    },
+    "ManagedInstanceKeyProperties": {
+      "type": "object",
+      "properties": {
+        "serverKeyType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "ServiceManaged",
+                "AzureKeyVault"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The key type like 'ServiceManaged', 'AzureKeyVault'."
+        },
+        "uri": {
+          "type": "string",
+          "description": "The URI of the key. If the ServerKeyType is AzureKeyVault, then the URI is required."
+        }
+      },
+      "required": [
+        "serverKeyType"
+      ],
+      "description": "Properties for a key execution."
+    },
+    "ManagedInstancePairInfo": {
+      "type": "object",
+      "properties": {
+        "partnerManagedInstanceId": {
+          "type": "string",
+          "description": "Id of Partner Managed Instance in pair."
+        },
+        "primaryManagedInstanceId": {
+          "type": "string",
+          "description": "Id of Primary Managed Instance in pair."
+        }
+      },
+      "description": "Pairs of Managed Instances in the failover group."
+    },
+    "PartnerRegionInfo": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Geo location of the partner managed instances."
+        }
+      },
+      "description": "Partner region information for the failover group."
+    },
+    "servers_databases_backupShortTermRetentionPolicies_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-10-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ],
+          "description": "The policy name. Should always be \"default\"."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/BackupShortTermRetentionPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a short term retention policy"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "backupShortTermRetentionPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies"
+    },
+    "Sku": {
+      "type": "object",
+      "properties": {
+        "capacity": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Capacity of the particular SKU."
+        },
+        "family": {
+          "type": "string",
+          "description": "If the service has different generations of hardware, for the same SKU, then that can be captured here."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the SKU, typically, a letter + Number code, e.g. P3."
+        },
+        "size": {
+          "type": "string",
+          "description": "Size of the particular SKU"
+        },
+        "tier": {
+          "type": "string",
+          "description": "The tier or edition of the particular SKU, e.g. Basic, Premium."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "description": "An ARM Resource SKU."
+    },
+    "VulnerabilityAssessmentRecurringScansProperties": {
+      "type": "object",
+      "properties": {
+        "emails": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies an array of e-mail addresses to which the scan notification is sent."
+        },
+        "emailSubscriptionAdmins": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "default": true
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies that the schedule scan notification will be is sent to the subscription administrators."
+        },
+        "isEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurring scans state."
+        }
+      },
+      "description": "Properties of a Vulnerability Assessment recurring scans."
+    }
+  }
+}

--- a/test/Resource/Expected/Microsoft.Sql/2018-06-01-preview/Microsoft.Sql.json
+++ b/test/Resource/Expected/Microsoft.Sql/2018-06-01-preview/Microsoft.Sql.json
@@ -1,0 +1,1103 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2018-06-01-preview/Microsoft.Sql.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Sql",
+  "description": "Microsoft Sql Resource Types",
+  "resourceDefinitions": {
+    "instancePools": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-06-01-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the instance pool to be created or updated."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/InstancePoolProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of an instance pool."
+        },
+        "sku": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Sku"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "An ARM Resource SKU."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/instancePools"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/instancePools"
+    },
+    "managedInstances": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-06-01-preview"
+          ]
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ResourceIdentity"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Azure Active Directory identity configuration for a resource."
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the managed instance."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedInstanceProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of a managed instance."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/managedInstances_vulnerabilityAssessments_childResource"
+              },
+              {
+                "$ref": "#/definitions/managedInstances_databases_childResource"
+              }
+            ]
+          }
+        },
+        "sku": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Sku"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "An ARM Resource SKU."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances"
+    },
+    "managedInstances_databases": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-06-01-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the database."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedDatabaseProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The managed database's properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances/databases"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/databases"
+    },
+    "managedInstances_databases_schemas_tables_columns_sensitivityLabels": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-06-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The source of the sensitivity label."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SensitivityLabelProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a sensitivity label."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances/databases/schemas/tables/columns/sensitivityLabels"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/databases/schemas/tables/columns/sensitivityLabels"
+    },
+    "managedInstances_vulnerabilityAssessments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-06-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the vulnerability assessment."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedInstanceVulnerabilityAssessmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a managed instance vulnerability assessment."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/managedInstances/vulnerabilityAssessments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/vulnerabilityAssessments"
+    },
+    "servers_databases_securityAlertPolicies": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-06-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the security alert policy."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SecurityAlertPolicyProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a security alert policy."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/databases/securityAlertPolicies"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/databases/securityAlertPolicies"
+    },
+    "servers_privateEndpointConnections": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-06-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the private endpoint connection."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PrivateEndpointConnectionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a private endpoint connection."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/privateEndpointConnections"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/privateEndpointConnections"
+    },
+    "servers_vulnerabilityAssessments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-06-01-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^.*/default$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the vulnerability assessment."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServerVulnerabilityAssessmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a server Vulnerability Assessment."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Sql/servers/vulnerabilityAssessments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/servers/vulnerabilityAssessments"
+    }
+  },
+  "definitions": {
+    "InstancePoolProperties": {
+      "type": "object",
+      "properties": {
+        "licenseType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "LicenseIncluded",
+                "BasePrice"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The license type. Possible values are 'LicenseIncluded' (price for SQL license is included) and 'BasePrice' (without SQL license price)."
+        },
+        "subnetId": {
+          "type": "string",
+          "description": "Resource ID of the subnet to place this instance pool in."
+        },
+        "vCores": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Count of vCores belonging to this instance pool."
+        }
+      },
+      "required": [
+        "licenseType",
+        "subnetId",
+        "vCores"
+      ],
+      "description": "Properties of an instance pool."
+    },
+    "ManagedDatabaseProperties": {
+      "type": "object",
+      "properties": {
+        "catalogCollation": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "DATABASE_DEFAULT",
+                "SQL_Latin1_General_CP1_CI_AS"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Collation of the metadata catalog."
+        },
+        "collation": {
+          "type": "string",
+          "description": "Collation of the managed database."
+        },
+        "createMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Default",
+                "RestoreExternalBackup",
+                "PointInTimeRestore",
+                "Recovery"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Managed database create mode. PointInTimeRestore: Create a database by restoring a point in time backup of an existing database. SourceDatabaseName, SourceManagedInstanceName and PointInTime must be specified. RestoreExternalBackup: Create a database by restoring from external backup files. Collation, StorageContainerUri and StorageContainerSasToken must be specified. Recovery: Creates a database by restoring a geo-replicated backup. RecoverableDatabaseId must be specified as the recoverable database resource ID to restore."
+        },
+        "recoverableDatabaseId": {
+          "type": "string",
+          "description": "The resource identifier of the recoverable database associated with create operation of this database."
+        },
+        "restorableDroppedDatabaseId": {
+          "type": "string",
+          "description": "The restorable dropped database resource id to restore when creating this database."
+        },
+        "restorePointInTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Conditional. If createMode is PointInTimeRestore, this value is required. Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database."
+        },
+        "sourceDatabaseId": {
+          "type": "string",
+          "description": "The resource identifier of the source database associated with create operation of this database."
+        },
+        "storageContainerSasToken": {
+          "type": "string",
+          "description": "Conditional. If createMode is RestoreExternalBackup, this value is required. Specifies the storage container sas token."
+        },
+        "storageContainerUri": {
+          "type": "string",
+          "description": "Conditional. If createMode is RestoreExternalBackup, this value is required. Specifies the uri of the storage container where backups for this restore are stored."
+        }
+      },
+      "description": "The managed database's properties."
+    },
+    "ManagedInstanceProperties": {
+      "type": "object",
+      "properties": {
+        "administratorLogin": {
+          "type": "string",
+          "description": "Administrator username for the managed instance. Can only be specified when the managed instance is being created (and is required for creation)."
+        },
+        "administratorLoginPassword": {
+          "type": "string",
+          "description": "The administrator login password (required for managed instance creation)."
+        },
+        "collation": {
+          "type": "string",
+          "description": "Collation of the managed instance."
+        },
+        "dnsZonePartner": {
+          "type": "string",
+          "description": "The resource id of another managed instance whose DNS zone this managed instance will share after creation."
+        },
+        "instancePoolId": {
+          "type": "string",
+          "description": "The Id of the instance pool this managed server belongs to."
+        },
+        "licenseType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "LicenseIncluded",
+                "BasePrice"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The license type. Possible values are 'LicenseIncluded' (regular price inclusive of a new SQL license) and 'BasePrice' (discounted AHB price for bringing your own SQL licenses)."
+        },
+        "managedInstanceCreateMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Default",
+                "PointInTimeRestore"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the mode of database creation.\r\n\r\nDefault: Regular instance creation.\r\n\r\nRestore: Creates an instance by restoring a set of backups to specific point in time. RestorePointInTime and SourceManagedInstanceId must be specified."
+        },
+        "proxyOverride": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Proxy",
+                "Redirect",
+                "Default"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Connection type used for connecting to the instance."
+        },
+        "publicDataEndpointEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether or not the public data endpoint is enabled."
+        },
+        "restorePointInTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database."
+        },
+        "sourceManagedInstanceId": {
+          "type": "string",
+          "description": "The resource identifier of the source managed instance associated with create operation of this instance."
+        },
+        "storageSizeInGB": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Storage size in GB. Minimum value: 32. Maximum value: 8192. Increments of 32 GB allowed only."
+        },
+        "subnetId": {
+          "type": "string",
+          "description": "Subnet resource ID for the managed instance."
+        },
+        "timezoneId": {
+          "type": "string",
+          "description": "Id of the timezone. Allowed values are timezones supported by Windows.\r\nWindows keeps details on supported timezones, including the id, in registry under\r\nKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Time Zones.\r\nYou can get those registry values via SQL Server by querying SELECT name AS timezone_id FROM sys.time_zone_info.\r\nList of Ids can also be obtained by executing [System.TimeZoneInfo]::GetSystemTimeZones() in PowerShell.\r\nAn example of valid timezone id is \"Pacific Standard Time\" or \"W. Europe Standard Time\"."
+        },
+        "vCores": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The number of vCores. Allowed values: 8, 16, 24, 32, 40, 64, 80."
+        }
+      },
+      "description": "The properties of a managed instance."
+    },
+    "managedInstances_databases_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-06-01-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the database."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedDatabaseProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The managed database's properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "databases"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/databases"
+    },
+    "managedInstances_vulnerabilityAssessments_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-06-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ],
+          "description": "The name of the vulnerability assessment."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedInstanceVulnerabilityAssessmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a managed instance vulnerability assessment."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "vulnerabilityAssessments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Sql/managedInstances/vulnerabilityAssessments"
+    },
+    "ManagedInstanceVulnerabilityAssessmentProperties": {
+      "type": "object",
+      "properties": {
+        "recurringScans": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/VulnerabilityAssessmentRecurringScansProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a Vulnerability Assessment recurring scans."
+        },
+        "storageAccountAccessKey": {
+          "type": "string",
+          "description": "Specifies the identifier key of the storage account for vulnerability assessment scan results. If 'StorageContainerSasKey' isn't specified, storageAccountAccessKey is required."
+        },
+        "storageContainerPath": {
+          "type": "string",
+          "description": "A blob storage container path to hold the scan results (e.g. https://myStorage.blob.core.windows.net/VaScans/)."
+        },
+        "storageContainerSasKey": {
+          "type": "string",
+          "description": "A shared access signature (SAS Key) that has write access to the blob container specified in 'storageContainerPath' parameter. If 'storageAccountAccessKey' isn't specified, StorageContainerSasKey is required."
+        }
+      },
+      "required": [
+        "storageContainerPath"
+      ],
+      "description": "Properties of a managed instance vulnerability assessment."
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "privateEndpoint": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PrivateEndpointProperty"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "privateLinkServiceConnectionState": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PrivateLinkServiceConnectionStateProperty"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "description": "Properties of a private endpoint connection."
+    },
+    "PrivateEndpointProperty": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource id of the private endpoint."
+        }
+      }
+    },
+    "PrivateLinkServiceConnectionStateProperty": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "The private link service connection description."
+        },
+        "status": {
+          "type": "string",
+          "description": "The private link service connection status."
+        }
+      },
+      "required": [
+        "description",
+        "status"
+      ]
+    },
+    "ResourceIdentity": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "SystemAssigned"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The identity type. Set this to 'SystemAssigned' in order to automatically create and assign an Azure Active Directory principal for the resource."
+        }
+      },
+      "description": "Azure Active Directory identity configuration for a resource."
+    },
+    "SecurityAlertPolicyProperties": {
+      "type": "object",
+      "properties": {
+        "disabledAlerts": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies an array of alerts that are disabled. Allowed values are: Sql_Injection, Sql_Injection_Vulnerability, Access_Anomaly, Data_Exfiltration, Unsafe_Action"
+        },
+        "emailAccountAdmins": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies that the alert is sent to the account administrators."
+        },
+        "emailAddresses": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies an array of e-mail addresses to which the alert is sent."
+        },
+        "retentionDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of days to keep in the Threat Detection audit logs."
+        },
+        "state": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "New",
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the state of the policy, whether it is enabled or disabled or a policy has not been applied yet on the specific database."
+        },
+        "storageAccountAccessKey": {
+          "type": "string",
+          "description": "Specifies the identifier key of the Threat Detection audit storage account."
+        },
+        "storageEndpoint": {
+          "type": "string",
+          "description": "Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all Threat Detection audit logs."
+        }
+      },
+      "required": [
+        "state"
+      ],
+      "description": "Properties of a security alert policy."
+    },
+    "SensitivityLabelProperties": {
+      "type": "object",
+      "properties": {
+        "informationType": {
+          "type": "string",
+          "description": "The information type."
+        },
+        "informationTypeId": {
+          "type": "string",
+          "description": "The information type ID."
+        },
+        "labelId": {
+          "type": "string",
+          "description": "The label ID."
+        },
+        "labelName": {
+          "type": "string",
+          "description": "The label name."
+        }
+      },
+      "description": "Properties of a sensitivity label."
+    },
+    "ServerVulnerabilityAssessmentProperties": {
+      "type": "object",
+      "properties": {
+        "recurringScans": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/VulnerabilityAssessmentRecurringScansProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a Vulnerability Assessment recurring scans."
+        },
+        "storageAccountAccessKey": {
+          "type": "string",
+          "description": "Specifies the identifier key of the storage account for vulnerability assessment scan results. If 'StorageContainerSasKey' isn't specified, storageAccountAccessKey is required."
+        },
+        "storageContainerPath": {
+          "type": "string",
+          "description": "A blob storage container path to hold the scan results (e.g. https://myStorage.blob.core.windows.net/VaScans/)."
+        },
+        "storageContainerSasKey": {
+          "type": "string",
+          "description": "A shared access signature (SAS Key) that has write access to the blob container specified in 'storageContainerPath' parameter. If 'storageAccountAccessKey' isn't specified, StorageContainerSasKey is required."
+        }
+      },
+      "required": [
+        "storageContainerPath"
+      ],
+      "description": "Properties of a server Vulnerability Assessment."
+    },
+    "Sku": {
+      "type": "object",
+      "properties": {
+        "capacity": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Capacity of the particular SKU."
+        },
+        "family": {
+          "type": "string",
+          "description": "If the service has different generations of hardware, for the same SKU, then that can be captured here."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the SKU, typically, a letter + Number code, e.g. P3."
+        },
+        "size": {
+          "type": "string",
+          "description": "Size of the particular SKU"
+        },
+        "tier": {
+          "type": "string",
+          "description": "The tier or edition of the particular SKU, e.g. Basic, Premium."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "description": "An ARM Resource SKU."
+    },
+    "VulnerabilityAssessmentRecurringScansProperties": {
+      "type": "object",
+      "properties": {
+        "emails": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies an array of e-mail addresses to which the scan notification is sent."
+        },
+        "emailSubscriptionAdmins": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "default": true
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies that the schedule scan notification will be is sent to the subscription administrators."
+        },
+        "isEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurring scans state."
+        }
+      },
+      "description": "Properties of a Vulnerability Assessment recurring scans."
+    }
+  }
+}

--- a/test/Resource/Expected/Microsoft.Web/2018-02-01/Microsoft.Web.json
+++ b/test/Resource/Expected/Microsoft.Web/2018-02-01/Microsoft.Web.json
@@ -4513,14 +4513,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/default$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "default"
           ]
         },
         "properties": {
@@ -6952,14 +6947,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/MSDeploy$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "MSDeploy"
           ]
         },
         "properties": {
@@ -7161,14 +7151,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/migrate$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "migrate"
           ]
         },
         "properties": {
@@ -7211,14 +7196,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/virtualNetwork$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "virtualNetwork"
           ]
         },
         "properties": {
@@ -7324,14 +7304,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/virtualNetworks$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "virtualNetworks"
           ]
         },
         "properties": {
@@ -7923,14 +7898,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/MSDeploy$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "MSDeploy"
           ]
         },
         "properties": {
@@ -8132,14 +8102,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/virtualNetwork$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "virtualNetwork"
           ]
         },
         "properties": {
@@ -8245,14 +8210,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/virtualNetworks$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "virtualNetworks"
           ]
         },
         "properties": {
@@ -8365,14 +8325,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/web$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "web"
           ]
         },
         "properties": {
@@ -8501,14 +8456,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/web$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "web"
           ]
         },
         "properties": {

--- a/test/Resource/Expected/Microsoft.Web/2018-11-01/Microsoft.Web.json
+++ b/test/Resource/Expected/Microsoft.Web/2018-11-01/Microsoft.Web.json
@@ -5912,14 +5912,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/MSDeploy$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "MSDeploy"
           ]
         },
         "properties": {
@@ -6091,14 +6086,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/migrate$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "migrate"
           ]
         },
         "properties": {
@@ -6141,14 +6131,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/virtualNetwork$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "virtualNetwork"
           ]
         },
         "properties": {
@@ -6254,14 +6239,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/virtualNetworks$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "virtualNetworks"
           ]
         },
         "properties": {
@@ -6853,14 +6833,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/MSDeploy$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "MSDeploy"
           ]
         },
         "properties": {
@@ -7032,14 +7007,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/virtualNetwork$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "virtualNetwork"
           ]
         },
         "properties": {
@@ -7145,14 +7115,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/virtualNetworks$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "virtualNetworks"
           ]
         },
         "properties": {
@@ -7265,14 +7230,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/web$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "web"
           ]
         },
         "properties": {
@@ -7401,14 +7361,9 @@
           "description": "Kind of resource."
         },
         "name": {
-          "oneOf": [
-            {
-              "type": "string",
-              "pattern": "^.*/web$"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
+          "type": "string",
+          "enum": [
+            "web"
           ]
         },
         "properties": {


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-resource-manager-schemas/pull/728#discussion_r338244128 (https://github.com/Azure/autorest/issues/2471)

1. Ensure resource names declared as single-enum parameters are treated as constants when generating schemas.
2. Ensure nested constant resource names are terminated with "/{constantName}" rather than enforcing an enum (fix for https://github.com/Azure/autorest/issues/2471).
3. Fix in-body child resource formatting - use an enum rather than a regex pattern.