### PR TITLE
Make properties case insensitive to prevent duplicate keys

### DIFF
--- a/src/JsonSchema.cs
+++ b/src/JsonSchema.cs
@@ -252,7 +252,8 @@ namespace AutoRest.AzureResourceSchema
             
             if (Properties == null)
             {
-                Properties = new Dictionary<string, JsonSchema>();
+                // Making insensitive dictionary to capture duplicate property keys.
+                Properties = new Dictionary<string, JsonSchema>(StringComparer.OrdinalIgnoreCase);
             }
 
             if (Properties.ContainsKey(propertyName))

--- a/test/JSONSchemaTests.cs
+++ b/test/JSONSchemaTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace AutoRest.AzureResourceSchema.Tests
@@ -72,6 +73,22 @@ namespace AutoRest.AzureResourceSchema.Tests
         {
             JsonSchema lhs = new JsonSchema();
             Assert.False(lhs.Equals("Not Equal"));
+        }
+
+        [Fact]
+        public void AddPropertyOverwriteWithSamePropertyNameButDifferentCasing()
+        {
+            JsonSchema jsonSchema = new JsonSchema();
+            jsonSchema.AddProperty("Type", new JsonSchema().AddProperty("foo1", new JsonSchema()));
+            jsonSchema.AddProperty("Name", new JsonSchema().AddProperty("foo2", new JsonSchema()));
+
+            jsonSchema.AddPropertyWithOverwrite("type", new JsonSchema().AddProperty("bar", new JsonSchema()), true);
+            jsonSchema.AddPropertyWithOverwrite("name", new JsonSchema().AddProperty("baz", new JsonSchema()), true);
+
+            var expectedPropertyNames = new string[] { "type", "name" };
+
+            Assert.True(jsonSchema.Properties.Count == 2);
+            Assert.True(expectedPropertyNames.All(jsonSchema.Properties.Select(property => property.Key).Contains));
         }
     }
 }


### PR DESCRIPTION
This PR fixes the scenario of adding duplicate properties (type, name, apiVersion) from [these](https://github.com/Azure/autorest.azureresourceschema/blob/master/src/ResourceSchemaParser.cs#L364-L366) lines. This happens when a swagger spec contains Type (capital T) property for example, by making the dictionary case insensitive, we are now able to detect duplicates and overwrite them.